### PR TITLE
Miscellaneous clarifications and cleaning up

### DIFF
--- a/lib/code/list.ex
+++ b/lib/code/list.ex
@@ -15,7 +15,7 @@ defmodule Igniter.Code.List do
     Common.node_matches_pattern?(zipper, value when is_list(value))
   end
 
-  @doc "Prepends `quoted` to the list unless it is alread present, determined by `equality_pred`."
+  @doc "Prepends `quoted` to the list unless it is already present, determined by `equality_pred`."
   @spec prepend_new_to_list(Zipper.t(), quoted :: Macro.t(), equality_pred) ::
           {:ok, Zipper.t()} | :error
   def prepend_new_to_list(zipper, quoted, equality_pred \\ &Common.nodes_equal?/2) do
@@ -36,7 +36,7 @@ defmodule Igniter.Code.List do
     end
   end
 
-  @doc "Appends `quoted` to the list unless it is alread present, determined by `equality_pred`."
+  @doc "Appends `quoted` to the list unless it is already present, determined by `equality_pred`."
   @spec append_new_to_list(Zipper.t(), quoted :: Macro.t(), equality_pred) ::
           {:ok, Zipper.t()} | :error
   def append_new_to_list(zipper, quoted, equality_pred \\ &Common.nodes_equal?/2) do


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

This is a minor PR aimed at slightly improving the readability of the code. In addition to the actual changes, I would like to propose the following (happy to implement myself, but wanted to discuss before jumping to writing code, esp since it might lead to deprecating previous names):

1. `Igniter.Code.Common.env_at_cursor/1` doesn't yet have a cursor (it gets inserted as the first step). Perhaps a more descriptive name would be `(get_)current_environment/1`?
2. The name for `Igniter.Code.Common.add_code/3` doesn't immediately indicate where the code is added. How's `insert_code/3` to explicitly indicate that it gets inserted exactly where the zipper is focused?
3. The name `Igniter.Code.Common.highest_adjacent_block/1` was a bit confusing to me (perhaps because the code nests left<->right while AST nests up<->down, and it's unclear which mode of thinking was necessary). How's something like `outer_containing_block/1`? (Separately, wouldn't it always return `defmodule`'s block? Or maybe I'm misunderstanding the functionality.)
4. `Igniter.Code.Common.maybe_move_to_singleton_block/1` was confusing to me because "singleton" also is a pattern from (trigger warning) OOP, so my first hunch was thinking about a "unique" block or something. After reading the code it seems that it simply means "block with one child". With this in mind, how's `maybe_move_to_single_child_block/1` or `maybe_move_to_single_expression_block/1`? I also still don't fully understand its purpose.

Separately, I often get confused by `move` since it's four-directional and depends on the orientation as described above. What do you think about using orientation-agnostic terms such as "ascend" (in AST-coordinates, it means go up; in code, it means to the left, indentation-wise), "descend", "next" as opposed to just "next" or "move", where possible? So, for example, `move_to_singleton_block` would become `descend_to_singleton_block`. UPD: reading it again and wondering if descend is still ambiguous and could be interpreted as moving up the AST 😐.

And finally, another thing that's a bit confusing is minor terminology like patterns vs predicates, nodes, etc. One example is `node_matches_pattern?/2` which actually accepts a zipper (which itself has a node, among other things). Another example is: in `Igniter.Code.Common.move_to/2`, it's a bit unclear what "predicate" is supposed to be.

Just wanted to flag these ideas since Igniter is still in its early stages and its API is still easy to modify/rename. Some of these suggestions probably only warrant documentation modifications, though.