### PR TITLE
Fix "Writing generators" code example + add source_url to enable link to code on HexDocs

### DIFF
--- a/documentation/writing-generators.md
+++ b/documentation/writing-generators.md
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.YourLib.Gen.YourThing do
     app_name = Igniter.Application.app_name()
 
     igniter
-    |> Igniter.create_new_elixir_file(igniter, path, """
+    |> Igniter.create_new_elixir_file(path, """
     defmodule #{inspect(module_name)} do
       use YourLib.Thing
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule Igniter.MixProject do
     [
       main: "readme",
       source_ref: "v#{@version}",
+      source_url: "https://github.com/ash-project/igniter",
       logo: "logos/igniter-logo-small.png",
       extra_section: "GUIDES",
       extras: [


### PR DESCRIPTION
Nice library! :D

I noticed a small error in the writing generators guide. When calling `create_new_elixir_file`, the `igniter` argument was specified twice.

Also adding `source_url` to `mix.exs` so that all functions have code links in HexDocs.