### PR TITLE
improvement: add proper_test_location/1

### DIFF
--- a/lib/code/module.ex
+++ b/lib/code/module.ex
@@ -10,9 +10,24 @@ defmodule Igniter.Code.Module do
     Module.concat(module_name_prefix(), suffix)
   end
 
-  @doc "Returns the idiomatic file location for a given module"
+  @doc """
+  Returns the idiomatic file location for a given module, starting with "lib/".
+  """
   @spec proper_location(module()) :: Path.t()
   def proper_location(module_name) do
+    do_proper_test_location(module_name)
+  end
+
+  @doc """
+  Returns the test file location for a given module, according to
+  `mix test` expectations, starting with "test/" and ending with "_test.exs"
+  """
+  @spec proper_test_location(module()) :: Path.t()
+  def proper_test_location(module_name) do
+    do_proper_test_location(module_name, :test)
+  end
+
+  defp do_proper_test_location(module_name, kind \\ :lib) do
     path =
       module_name
       |> Module.split()
@@ -22,7 +37,17 @@ defmodule Igniter.Code.Module do
     last = List.last(path)
     leading = :lists.droplast(path)
 
-    Path.join(["lib" | leading] ++ ["#{last}.ex"])
+    case kind do
+      :lib ->
+        Path.join(["lib" | leading] ++ ["#{last}.ex"])
+
+      :test ->
+        if String.ends_with?(last, "_test") do
+          Path.join(["test" | leading] ++ ["#{last}.exs"])
+        else
+          Path.join(["test" | leading] ++ ["#{last}_test.exs"])
+        end
+    end
   end
 
   def module?(zipper) do

--- a/test/code/module_test.exs
+++ b/test/code/module_test.exs
@@ -1,0 +1,18 @@
+defmodule Igniter.Code.ModuleTest do
+  use ExUnit.Case
+
+  test "proper_location/1 returns idiomatic path" do
+    assert "lib/my_app/hello.ex" = Igniter.Code.Module.proper_location(MyApp.Hello)
+  end
+
+  describe "proper_test_location/1" do
+    test "returns a path with _test appended if the module name doesn't end with Test" do
+      assert "test/my_app/hello_test.exs" = Igniter.Code.Module.proper_test_location(MyApp.Hello)
+    end
+
+    test "returns a path without appending _test if the module name already ends with Test" do
+      assert "test/my_app/hello_test.exs" =
+               Igniter.Code.Module.proper_test_location(MyApp.HelloTest)
+    end
+  end
+end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

Adds `Igniter.Code.Module.proper_test_location/1` in order to be able to output test file paths, i.e. `MyApp.HelloTest` -> `test/my_app/hello_test.exs`.

Note: I'm not sure if it's a common scenario to have the test file _not_ end with `Test` in the module name, but I wanted to account for it just in case.