### PR TITLE
fix: version string splitting

### DIFF
--- a/lib/util/install.ex
+++ b/lib/util/install.ex
@@ -175,7 +175,7 @@ defmodule Igniter.Util.Install do
   end
 
   defp determine_dep_type_and_version(requirement) do
-    case String.split(requirement, "@", trim: true) do
+    case String.split(requirement, "@", trim: true, parts: 2) do
       [package] ->
         if Regex.match?(~r/^[a-z][a-z0-9_]*$/, package) do
           case Req.get!("https://hex.pm/api/packages/#{package}").body do


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR fixes how the dependency version string is parsed in `igniter.install`. Right now, adding a `ref` with another `@` at the end raises a match error because the first split produces three parts instead of two, making lines 201 and 214 are not reachable.