### PR TITLE
improvement: add Igniter.apply_and_fetch_dependencies/1 and Igniter.has_changes?/1

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -370,6 +370,74 @@ defmodule Igniter do
   end
 
   @doc """
+  Applies the current changes in the Igniter and fetches dependencies.
+
+  Returns an empty Igniter if successful.
+  """
+  def apply_and_fetch_dependencies(igniter) do
+    if has_changes?(igniter) do
+      case Igniter.do_or_dry_run(igniter, ["--dry-run"], title: "Preview") do
+        :issues ->
+          raise "Exiting due to issues found while previewing changes."
+
+        _ ->
+          proceed? =
+            Mix.shell().yes?("""
+            Before continuing, we need to first apply the changes and install dependencies. Would you like to do so now?
+            """)
+
+          if proceed? do
+            :changes_made = Igniter.do_or_dry_run(igniter, ["--yes"], title: "Applying changes")
+
+            Mix.shell().info("running mix deps.get")
+
+            case Mix.shell().cmd("mix deps.get") do
+              0 ->
+                Mix.Project.clear_deps_cache()
+                Mix.Project.pop()
+
+                "mix.exs"
+                |> File.read!()
+                |> Code.eval_string([], file: Path.expand("mix.exs"))
+
+                Mix.Dep.clear_cached()
+                Mix.Project.clear_deps_cache()
+
+                Mix.Task.run("deps.compile")
+
+                Mix.Task.reenable("compile")
+                Mix.Task.run("compile")
+
+              exit_code ->
+                Mix.shell().info("""
+                mix deps.get returned exited with code: `#{exit_code}`
+                """)
+            end
+
+            Igniter.new()
+          else
+            raise "Aborted by the user."
+          end
+      end
+    else
+      igniter
+    end
+  end
+
+  @doc """
+  Returns whether the current Igniter has pending changes.
+  """
+  def has_changes?(igniter) do
+    igniter.rewrite
+    |> Rewrite.sources()
+    |> Enum.filter(&Rewrite.Source.updated?(&1))
+    |> case do
+      [] -> false
+      _ -> true
+    end
+  end
+
+  @doc """
   Executes or dry-runs a given Igniter.
 
   This takes `argv` to parameterize it as it is generally invoked from a mix task.
@@ -409,66 +477,60 @@ defmodule Igniter do
         case igniter do
           %{issues: []} ->
             result_of_dry_run =
-              sources
-              |> Enum.filter(fn source ->
-                Rewrite.Source.updated?(source)
-              end)
-              |> case do
-                [] ->
-                  unless opts[:quiet_on_no_changes?] || "--yes" in argv do
-                    Mix.shell().info("\n#{title}: No proposed changes!\n")
-                  end
+              if has_changes?(igniter) do
+                if "--dry-run" in argv || "--yes" not in argv do
+                  Mix.shell().info("\n#{title}: Proposed changes:\n")
 
-                  :dry_run_with_no_changes
+                  Enum.each(sources, fn source ->
+                    if Rewrite.Source.from?(source, :string) do
+                      content_lines =
+                        source
+                        |> Rewrite.Source.get(:content)
+                        |> String.split("\n")
+                        |> Enum.with_index()
 
-                sources ->
-                  if "--dry-run" in argv || "--yes" not in argv do
-                    Mix.shell().info("\n#{title}: Proposed changes:\n")
+                      space_padding =
+                        content_lines
+                        |> Enum.map(&elem(&1, 1))
+                        |> Enum.max()
+                        |> to_string()
+                        |> String.length()
 
-                    Enum.each(sources, fn source ->
-                      if Rewrite.Source.from?(source, :string) do
-                        content_lines =
-                          source
-                          |> Rewrite.Source.get(:content)
-                          |> String.split("\n")
-                          |> Enum.with_index()
+                      diffish_looking_text =
+                        Enum.map_join(content_lines, "\n", fn {line, line_number_minus_one} ->
+                          line_number = line_number_minus_one + 1
 
-                        space_padding =
-                          content_lines
-                          |> Enum.map(&elem(&1, 1))
-                          |> Enum.max()
-                          |> to_string()
-                          |> String.length()
+                          "#{String.pad_trailing(to_string(line_number), space_padding)} #{IO.ANSI.yellow()}| #{IO.ANSI.green()}#{line}#{IO.ANSI.reset()}"
+                        end)
 
-                        diffish_looking_text =
-                          Enum.map_join(content_lines, "\n", fn {line, line_number_minus_one} ->
-                            line_number = line_number_minus_one + 1
+                      if String.trim(diffish_looking_text) != "" do
+                        Mix.shell().info("""
+                        Create: #{Rewrite.Source.get(source, :path)}
 
-                            "#{String.pad_trailing(to_string(line_number), space_padding)} #{IO.ANSI.yellow()}| #{IO.ANSI.green()}#{line}#{IO.ANSI.reset()}"
-                          end)
-
-                        if String.trim(diffish_looking_text) != "" do
-                          Mix.shell().info("""
-                          Create: #{Rewrite.Source.get(source, :path)}
-
-                          #{diffish_looking_text}
-                          """)
-                        end
-                      else
-                        diff = Rewrite.Source.diff(source) |> IO.iodata_to_binary()
-
-                        if String.trim(diff) != "" do
-                          Mix.shell().info("""
-                          Update: #{Rewrite.Source.get(source, :path)}
-
-                          #{diff}
-                          """)
-                        end
+                        #{diffish_looking_text}
+                        """)
                       end
-                    end)
-                  end
+                    else
+                      diff = Rewrite.Source.diff(source) |> IO.iodata_to_binary()
 
-                  :dry_run_with_changes
+                      if String.trim(diff) != "" do
+                        Mix.shell().info("""
+                        Update: #{Rewrite.Source.get(source, :path)}
+
+                        #{diff}
+                        """)
+                      end
+                    end
+                  end)
+                end
+
+                :dry_run_with_changes
+              else
+                unless opts[:quiet_on_no_changes?] || "--yes" in argv do
+                  Mix.shell().info("\n#{title}: No proposed changes!\n")
+                end
+
+                :dry_run_with_no_changes
               end
 
             if igniter.warnings != [] do

--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -54,7 +54,7 @@ defmodule Igniter.Util.Install do
         end
       end)
 
-    igniter = Igniter.apply_and_fetch_dependencies(igniter)
+    igniter = Igniter.apply_and_fetch_dependencies(igniter, cancel_on_abort?: true)
 
     desired_tasks = Enum.map(install_list, &"#{&1}.install")
 


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR implements https://github.com/ash-project/igniter/issues/24 and refactors `Igniter.Util.Install` to use it. It also adds `Igniter.has_changes?/1` and changes one place where it's relevant. The logic in the installer is now as follows: if there are changes when running `Igniter.apply_and_fetch_dependencies/1`, prompt the user to accept them and install dependencies. If not, do nothing and move on. 

Open question: do we still need the `options` variable in the installer, considering the changes? (I marked it with `# TODO` in the code for now.) Marking as draft for now.