### PR TITLE
fix: always return {:ok, zipper} in append_new_to_list/2

### DIFF
--- a/lib/igniter/code/list.ex
+++ b/lib/igniter/code/list.ex
@@ -50,7 +50,7 @@ defmodule Igniter.Code.List do
           append_to_list(zipper, quoted)
 
         _ ->
-          zipper
+          {:ok, zipper}
       end
     else
       :error


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

There's currently a minor inconsistency between `Igniter.Code.List.append_new_to_list/2` and `Igniter.Code.List.prepend_new_to_list/2`, namely, `append_new_to_list/2` sometimes returns `zipper` and sometimes `{:ok, zipper}`. This PR is a minor fix to ensure `{:ok, zipper}` is always returned.