### PR TITLE
fix: include only "mix.exs" in the actual run in apply_and_fetch_dependencies

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -414,7 +414,12 @@ defmodule Igniter do
             Mix.shell().yes?(message)
 
           if proceed? do
-            :changes_made = Igniter.do_or_dry_run(igniter, yes: true, title: "Applying changes")
+            :changes_made =
+              Igniter.do_or_dry_run(igniter,
+                yes: true,
+                title: "Applying changes",
+                paths: ["mix.exs"]
+              )
 
             Mix.shell().info("running mix deps.get")
 


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

There's a bug in `Igniter.apply_and_fetch_dependencies/2`, which is that changes are previewed only for `mix.exs` but run on _all_ files. This PR adds a path for `mix.exs` to the actual Igniter invocation.