### PR TITLE
fix: preserve original ordering in Util.Install

### DIFF
--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -55,6 +55,10 @@ defmodule Igniter.Util.Install do
       end)
       |> Stream.filter(&implements_behaviour?(&1, Igniter.Mix.Task))
       |> Enum.filter(&(Mix.Task.task_name(&1) in desired_tasks))
+      |> Enum.sort_by(
+        &Enum.find_index(desired_tasks, fn e -> e == Mix.Task.task_name(&1) end),
+        &<=/2
+      )
 
     title =
       case desired_tasks do


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Depending on the order in which Mix loads tasks, the original installer ordering may be lost. For example, `mix igniter.install ash_postgres@path:../ash_postgres,ash_money@path:../ash_money` installs AshMoney before AshPostgres. This PR adds a sorting step to return the original ordering passed as arguments to `igniter.install`.
