### PR TITLE
fix: pass file_path to `ensure_default_configs_exist`

### DIFF
--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -56,7 +56,7 @@ defmodule Igniter.Project.Config do
     updater = opts[:updater] || fn zipper -> {:ok, Common.replace_code(zipper, value)} end
 
     igniter
-    |> ensure_default_configs_exist(file_name)
+    |> ensure_default_configs_exist(file_path)
     |> Igniter.include_or_create_elixir_file(file_path, file_contents)
     |> Igniter.update_elixir_file(file_path, fn zipper ->
       case Zipper.find(zipper, fn


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

There's a tiny subtle bug when ensuring default configs exist, which is that `file_name` (i.e. `dev.exs`) is passed into `ensure_default_configs_exist` which has guards on file paths instead, i.e. `config/dev.exs`, so it never gets invoked. This PR fixes it by passing the full `file_path` instead.