### PR TITLE
fix: remove Elixir from module_name_prefix

### DIFF
--- a/lib/igniter/code/module.ex
+++ b/lib/igniter/code/module.ex
@@ -386,10 +386,7 @@ defmodule Igniter.Code.Module do
   @doc "The module name prefix based on the mix project's module name"
   @spec module_name_prefix() :: module()
   def module_name_prefix do
-    Mix.Project.get!()
-    |> Module.split()
-    |> :lists.droplast()
-    |> Module.concat()
+    Mix.Project.get!() |> Module.split() |> List.first() |> String.to_atom()
   end
 
   @doc "Moves the zipper to a defmodule call"


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

I do not know why, but the original implementation in some cases prepends `Elixir` to the return value in `Igniter.Code.Module.module_name_prefix/0`, whereas in some cases it doesn't. However, the new implementation empirically never prepends it.
