### PR TITLE
refactor: simplify zipper usage

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 26.0.2
-elixir 1.17.1
+elixir 1.17.1-otp-26

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -209,6 +209,10 @@ defmodule Igniter.Code.Common do
     end
   end
 
+  @doc """
+  Replaces full module names in `new_code` with any aliases for that
+  module found in the `current_code` environment.
+  """
   def use_aliases(new_code, current_code) do
     case current_env(current_code) do
       {:ok, env} ->

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -201,22 +201,11 @@ defmodule Igniter.Code.Common do
 
   defp highest_adjacent_block(zipper) do
     case Zipper.up(zipper) do
-      nil ->
+      %Zipper{node: {:__block__, _, _}} = upwards ->
+        highest_adjacent_block(upwards) || upwards
+
+      _ ->
         nil
-
-      upwards ->
-        upwards
-        |> Zipper.node()
-        |> case do
-          {:__block__, _, _} ->
-            case highest_adjacent_block(upwards) do
-              nil -> upwards
-              zipper -> zipper
-            end
-
-          _ ->
-            nil
-        end
     end
   end
 

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -154,37 +154,27 @@ defmodule Igniter.Code.Common do
         zipper
         |> highest_adjacent_block()
         |> case do
-          nil ->
+          %Zipper{node: {:__block__, meta, stuff}} = upwards ->
+            new_stuff =
+              if placement == :after do
+                List.wrap(stuff) ++ [new_code]
+              else
+                case List.wrap(stuff) do
+                  [first | rest] ->
+                    [first, new_code | rest]
+
+                  _ ->
+                    [new_code | stuff]
+                end
+              end
+
+            Zipper.replace(upwards, {:__block__, meta, new_stuff})
+
+          _ ->
             if placement == :after do
               Zipper.replace(zipper, {:__block__, [], [code, new_code]})
             else
               Zipper.replace(zipper, {:__block__, [], [new_code, code]})
-            end
-
-          upwards ->
-            case upwards.node do
-              {:__block__, meta, stuff} ->
-                new_stuff =
-                  if placement == :after do
-                    List.wrap(stuff) ++ [new_code]
-                  else
-                    case List.wrap(stuff) do
-                      [first | rest] ->
-                        [first, new_code | rest]
-
-                      _ ->
-                        [new_code | stuff]
-                    end
-                  end
-
-                Zipper.replace(upwards, {:__block__, meta, new_stuff})
-
-              _ ->
-                if placement == :after do
-                  Zipper.replace(zipper, {:__block__, [], [code, new_code]})
-                else
-                  Zipper.replace(zipper, {:__block__, [], [new_code, code]})
-                end
             end
         end
     end

--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -13,12 +13,7 @@ defmodule Igniter.Code.Function do
         unquote(zipper),
         unquote(index),
         fn zipper ->
-          code_at_node =
-            zipper
-            |> Sourceror.Zipper.subtree()
-            |> Sourceror.Zipper.root()
-
-          match?(unquote(pattern), code_at_node)
+          match?(unquote(pattern), zipper.node)
         end
       )
     end
@@ -87,8 +82,7 @@ defmodule Igniter.Code.Function do
   def function_call?(%Zipper{} = zipper, name, arity) do
     zipper
     |> Common.maybe_move_to_single_child_block()
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> case do
       {^name, _, args} ->
         Enum.count(args) == arity
@@ -112,8 +106,7 @@ defmodule Igniter.Code.Function do
   def function_call?(%Zipper{} = zipper, name) do
     zipper
     |> Common.maybe_move_to_single_child_block()
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> case do
       {^name, _, _} ->
         true
@@ -137,8 +130,7 @@ defmodule Igniter.Code.Function do
   def function_call?(%Zipper{} = zipper) do
     zipper
     |> Common.maybe_move_to_single_child_block()
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> case do
       {:|>, _, [{name, _, context} | _rest]} when is_atom(context) and is_atom(name) ->
         true
@@ -391,10 +383,7 @@ defmodule Igniter.Code.Function do
   end
 
   defp pipeline?(zipper) do
-    zipper
-    |> Zipper.subtree()
-    |> Zipper.root()
-    |> case do
+    case zipper.node do
       {:|>, _, _} -> true
       _ -> false
     end

--- a/lib/igniter/code/keyword.ex
+++ b/lib/igniter/code/keyword.ex
@@ -117,10 +117,7 @@ defmodule Igniter.Code.Keyword do
           value = Common.use_aliases(value, zipper)
 
           to_append =
-            zipper
-            |> Zipper.subtree()
-            |> Zipper.node()
-            |> case do
+            case zipper.node do
               [{{:__block__, meta, _}, _} | _] ->
                 if meta[:format] do
                   {{:__block__, [format: meta[:format]], [key]}, {:__block__, [], [value]}}
@@ -172,10 +169,7 @@ defmodule Igniter.Code.Keyword do
            end) do
         :error ->
           to_append =
-            zipper
-            |> Zipper.subtree()
-            |> Zipper.node()
-            |> case do
+            case zipper.node do
               [{{:__block__, meta, _}, {:__block__, _, _}} | _] ->
                 value =
                   value

--- a/lib/igniter/code/map.ex
+++ b/lib/igniter/code/map.ex
@@ -136,10 +136,7 @@ defmodule Igniter.Code.Map do
   end
 
   defp map_keys_format(zipper) do
-    zipper
-    |> Zipper.subtree()
-    |> Zipper.node()
-    |> case do
+    case zipper.node do
       value when is_list(value) ->
         Enum.all?(value, fn
           {:__block__, meta, _} ->

--- a/lib/igniter/code/module.ex
+++ b/lib/igniter/code/module.ex
@@ -156,17 +156,13 @@ defmodule Igniter.Code.Module do
         |> Rewrite.Source.get(:quoted)
         |> Zipper.zip()
         |> Zipper.traverse([], fn zipper, acc ->
-          zipper
-          |> Zipper.subtree()
-          |> Zipper.node()
-          |> case do
+          case zipper.node do
             {:defmodule, _, [_, _]} ->
               {:ok, mod_zipper} = Igniter.Code.Function.move_to_nth_argument(zipper, 0)
 
               module_name =
                 mod_zipper
                 |> Igniter.Code.Common.expand_alias()
-                |> Zipper.subtree()
                 |> Zipper.node()
                 |> Igniter.Code.Module.to_module_name()
 
@@ -265,7 +261,6 @@ defmodule Igniter.Code.Module do
            module <-
              zipper
              |> Igniter.Code.Common.expand_alias()
-             |> Zipper.subtree()
              |> Zipper.node(),
            module when not is_nil(module) <- to_module_name(module),
            new_path when not is_nil(new_path) <-

--- a/lib/igniter/code/tuple.ex
+++ b/lib/igniter/code/tuple.ex
@@ -8,10 +8,7 @@ defmodule Igniter.Code.Tuple do
   @doc "Returns `true` if the zipper is at a literal tuple, `false` if not."
   @spec tuple?(Zipper.t()) :: boolean()
   def tuple?(item) do
-    item
-    |> Zipper.subtree()
-    |> Zipper.root()
-    |> case do
+    case item.node do
       {:{}, _, _} -> true
       {_, _} -> true
       _ -> false

--- a/lib/igniter/project/deps.ex
+++ b/lib/igniter/project/deps.ex
@@ -89,7 +89,6 @@ defmodule Igniter.Project.Deps do
              end
            end) do
       current_declaration
-      |> Zipper.subtree()
       |> Zipper.node()
       |> Sourceror.to_string()
     else

--- a/lib/igniter/util/debug.ex
+++ b/lib/igniter/util/debug.ex
@@ -5,8 +5,7 @@ defmodule Igniter.Util.Debug do
   @doc "Puts the formatted code at the node of the zipper to the console"
   def puts_code_at_node(zipper) do
     zipper
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> Sourceror.to_string()
     |> then(&"==code==\n#{&1}\n==code==\n")
     |> IO.puts()
@@ -17,16 +16,14 @@ defmodule Igniter.Util.Debug do
   @doc "Returns the formatted code at the node of the zipper to the console"
   def code_at_node(zipper) do
     zipper
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> Sourceror.to_string()
   end
 
   @doc "Puts the ast at the node of the zipper to the console"
   def puts_ast_at_node(zipper) do
     zipper
-    |> Zipper.subtree()
-    |> Zipper.root()
+    |> Zipper.node()
     |> then(&"==ast==\n#{inspect(&1, pretty: true)}\n==ast==\n")
     |> IO.puts()
 


### PR DESCRIPTION
I love just browsing and reading code, and while doing so with `Igniter`, noticed some zipper usage that couple be simplified.

Commits are atomic and can be reviewed independently. Happy to omit anything you don't want; just let me know. 🙂 