### PR TITLE
chore: remove :kind from docs

### DIFF
--- a/lib/igniter/code/module.ex
+++ b/lib/igniter/code/module.ex
@@ -15,7 +15,6 @@ defmodule Igniter.Code.Module do
   # Options
 
   - `:path` - Path where to create the module, relative to the project root. Default: `nil` (uses `:kind` to determine the path).
-  - `:kind` - Type of module being created. Possible values: `:lib`, `:test`, `:test_support` (default: `:lib`). Ignored if `:path` is set.
   """
   def find_and_update_or_create_module(igniter, module_name, contents, updater, opts \\ [])
 


### PR DESCRIPTION
Seems like we forgot to remove `:kind` from the documentation for `find_and_update_or_create_module/5` when we went with the `:path` option only.
