### PR TITLE
improvement: support tuple dependencies in igniter.install

### DIFF
--- a/lib/igniter/util/info.ex
+++ b/lib/igniter/util/info.ex
@@ -16,8 +16,9 @@ defmodule Igniter.Util.Info do
 
     igniter =
       add_deps(
-        igniter || Igniter.new(),
-        List.wrap(schema.adds_deps) ++ List.wrap(schema.installs)
+        igniter,
+        List.wrap(schema.adds_deps) ++ List.wrap(schema.installs),
+        opts
       )
 
     case schema.installs do
@@ -46,9 +47,9 @@ defmodule Igniter.Util.Info do
     end
   end
 
-  defp add_deps(igniter, add_deps) do
+  defp add_deps(igniter, add_deps, opts) do
     Enum.reduce(add_deps, igniter, fn dependency, igniter ->
-      Igniter.Project.Deps.add_dep(igniter, dependency)
+      Igniter.Project.Deps.add_dep(igniter, dependency, opts)
     end)
   end
 

--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -1,5 +1,7 @@
 defmodule Igniter.Util.Install do
-  @moduledoc false
+  @moduledoc """
+  Tools for installing packages and running their associated Igniter installers, if present.
+  """
 
   @doc """
   Installs the provided list of dependencies. `deps` can be either:

--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -1,6 +1,12 @@
 defmodule Igniter.Util.Install do
   @moduledoc """
-  Tools for installing packages and running their associated Igniter installers, if present.
+  Tools for installing packages and running their associated
+  installers, if present.
+
+  [!NOTE]
+  The functions in this module are not composable, and are primarily meant to
+  be used internally and to support building custom tooling on top of Igniter,
+  such as [Fireside](https://github.com/ibarakaiev/fireside).
   """
 
   @doc """

--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -12,7 +12,7 @@ defmodule Igniter.Util.Install do
   def install(deps, argv, igniter, opts) when is_binary(deps) do
     deps = String.split(deps, ",")
 
-    install(deps, argv, igniter)
+    install(deps, argv, igniter, opts)
   end
 
   def install([head | _] = deps, argv, igniter, opts) when is_binary(head) do
@@ -27,7 +27,7 @@ defmodule Igniter.Util.Install do
         end
       end)
 
-    install(deps, argv, igniter)
+    install(deps, argv, igniter, opts)
   end
 
   def install([head | _] = deps, argv, igniter, opts) when is_tuple(head) do


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR refactors `Igniter.Util.Install.install/3` into three different function clauses where `deps` can be either a string (separated with a comma), a list of strings, or a list of source dependencies (i.e. `{:ash, "~> 3.0"}`). This makes it possible to run `igniter.install` from a non-CLI context. This PR also adds a fourth `opts` function argument to `Igniter.Util.Install.install/3` (now `install/4`) and propagates it to `Igniter.Util.Info`. Note: I also removed `Application.ensure_all_started(:req)` since `Req` is not used anymore it seems.