### PR TITLE
improvement: add Function.argument_equals?/3

### DIFF
--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -384,7 +384,7 @@ defmodule Igniter.Code.Function do
         &Igniter.Code.Common.nodes_equal?(&1, term)
       )
     else
-      raise "The provided zipper is not a function call."
+      false
     end
   end
 

--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -7,7 +7,11 @@ defmodule Igniter.Code.Function do
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 
-  @doc "Returns `true` if the argument at the provided index exists and matches the provided pattern"
+  @doc """
+  Returns `true` if the argument at the provided index exists and matches the provided pattern
+
+  Note: to check for argument equality, use `argument_equals?/3` instead.
+  """
   defmacro argument_matches_pattern?(zipper, index, pattern) do
     quote do
       Igniter.Code.Function.argument_matches_predicate?(
@@ -365,6 +369,14 @@ defmodule Igniter.Code.Function do
     else
       :error
     end
+  end
+
+  def argument_equals?(zipper, index, term) do
+    Igniter.Code.Function.argument_matches_predicate?(
+      zipper,
+      index,
+      &Igniter.Code.Common.nodes_equal?(&1, term)
+    )
   end
 
   @doc "Returns true if the argument at the given index matches the provided predicate"

--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -371,12 +371,21 @@ defmodule Igniter.Code.Function do
     end
   end
 
+  @doc """
+  Checks if the provided function call (in a Zipper) has an argument that equals
+  `term` at `index`.
+  """
+  @spec argument_equals?(Zipper.t(), integer(), any()) :: boolean()
   def argument_equals?(zipper, index, term) do
-    Igniter.Code.Function.argument_matches_predicate?(
-      zipper,
-      index,
-      &Igniter.Code.Common.nodes_equal?(&1, term)
-    )
+    if function_call?(zipper) do
+      Igniter.Code.Function.argument_matches_predicate?(
+        zipper,
+        index,
+        &Igniter.Code.Common.nodes_equal?(&1, term)
+      )
+    else
+      raise "The provided zipper is not a function call."
+    end
   end
 
   @doc "Returns true if the argument at the given index matches the provided predicate"

--- a/test/igniter/code/function_test.exs
+++ b/test/igniter/code/function_test.exs
@@ -33,4 +33,17 @@ defmodule Igniter.Code.FunctionTest do
       assert Igniter.Util.Debug.code_at_node(zipper) == "x = 5"
     end
   end
+
+  test "argument_equals?/3" do
+    zipper =
+      "config :key, Test"
+      |> Sourceror.parse_string!()
+      |> Sourceror.Zipper.zip()
+
+    assert Igniter.Code.Function.argument_equals?(zipper, 0, :key) == true
+    assert Igniter.Code.Function.argument_equals?(zipper, 0, Test) == false
+
+    assert Igniter.Code.Function.argument_equals?(zipper, 1, :key) == false
+    assert Igniter.Code.Function.argument_equals?(zipper, 1, Test) == true
+  end
 end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

This PR adds `Igniter.Code.Function.argument_equals?/3` to make it easy to check argument equality. It also adds a note to `Function.argument_matches_pattern?/3` to clarify that equality checks should be done with `argument_equals?/3`.