### PR TITLE
fix: configures?/3 -> configures_key & configures_root_key

### DIFF
--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -453,7 +453,7 @@ defmodule Igniter.Code.Function do
         end
       end
     else
-      :error
+      raise "The passed Zipper is not a function."
     end
   end
 

--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -453,7 +453,7 @@ defmodule Igniter.Code.Function do
         end
       end
     else
-      raise "The passed Zipper is not a function."
+      false
     end
   end
 


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

This PR splits (and deprecates) `Igniter.Project.Config.configures?/3` into `Igniter.Project.Config.configures_key/4` and `Igniter.Project.Config.configures_root_key/3` to allow passing just the root key, atom keys, and list keys (as keyword paths).

Additionally, it addresses some of the issues discussed in #51, specifically, it:
- moves `Igniter.Code.Keyword.keyword_has_path?/2` inside the matching function in `Igniter.Code.Function.move_to_function_call_in_current_scope/4` to make sure deeply nested keys defined in a _later_ (that is, not first) run of the same root key configuration is checked. Previously, it was matching on the root key and checking it within a `case`, so there was a possibility it would match on the first occurrence, fail to find a nested key, and return `false` immediately.
- makes sure only boolean values are ever returned.
- supports both `config :root_key, :key, 1` as well as `config :root_key, key: 1` notations (as well as their deeply nested counterparts).
- makes the order and naming more consistent with Elixir's `Config.config/2,3`, that is, using `root_key` (instead of `app_name`) and using it earlier in the arguments.