### PR TITLE
improvement: include config in include_all_elixir_files

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -492,7 +492,7 @@ defmodule Igniter do
         igniter
       else
         igniter
-        |> include_glob("{lib,test}/**/*.{ex,exs}")
+        |> include_glob("{lib,test,config}/**/*.{ex,exs}")
         |> assign_private(:included_all_elixir_files?, true)
       end
     end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Adding the `config` directory to `include_all_elixir_files/1` since Igniter works with configs frequently.