### PR TITLE
Replacing the Application module with the generic application module that gets derived from the function args

### DIFF
--- a/lib/igniter/project/application.ex
+++ b/lib/igniter/project/application.ex
@@ -64,7 +64,7 @@ defmodule Igniter.Project.Application do
       end
 
     Igniter.update_elixir_file(igniter, path, fn zipper ->
-      with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, Application),
+      with {:ok, zipper} <- Igniter.Code.Module.move_to_module_using(zipper, application),
            {:ok, zipper} <- Igniter.Code.Function.move_to_def(zipper, :start, 2),
            {:ok, zipper} <-
              Igniter.Code.Function.move_to_function_call_in_current_scope(


### PR DESCRIPTION
Please let me know if this change is not correct. I'm just starting to make use of this library and I think I noticed an issue with the do_add_child function. It seems that the module that should be getting changed should be the generic application that the user passes in, which is not necessarily the Application module.

I am very new to Igniter and Elixir in general, just trying to help if there's an actual issue here.

### Contributor checklist

- [  ] Bug fixes include regression tests
- [  ] Features include unit/acceptance tests
