### PR TITLE
check for extendable_block?/1 in maybe_move_to_single_child_block/1

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -384,15 +384,19 @@ defmodule Igniter.Code.Common do
 
   def maybe_move_to_single_child_block(zipper) do
     case zipper.node do
-      {:__block__, _, [_]} ->
-        zipper
-        |> Zipper.down()
-        |> case do
-          nil ->
-            zipper
+      {:__block__, _, [_]} = block ->
+        if extendable_block?(block) do
+          zipper
+          |> Zipper.down()
+          |> case do
+            nil ->
+              zipper
 
-          zipper ->
-            maybe_move_to_single_child_block(zipper)
+            zipper ->
+              maybe_move_to_single_child_block(zipper)
+          end
+        else
+          zipper
         end
 
       _ ->


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Creating a PR following the conversation in Igniter discord.

### Context

If I have something like `config :my_app, SomeModule, key1: [version: 1]` and I use `Igniter.Project.Config.configure(...)` to update the value to another integer (say, 2), under the hood it changes the version to:
```elixir
{:__block__, [trailing_comments: [], leading_comments: [], token: "1", ...], [2]}
```
but running `Sourceror.to_string/1` on the above produces `config my_app,  SomeModule, key1: [version: 1]` again because of the `token: "1"`. (The behavior is similar in Elixir's `Macro` itself.)

The current approach is implementing @zachdaniel's suggestion but so far it breaks several tests (and most likely some things elsewhere too).