### PR TITLE
fix: :error consistency in remove_keyword_key and argument_equals? in Config.configure

### DIFF
--- a/lib/igniter/code/keyword.ex
+++ b/lib/igniter/code/keyword.ex
@@ -215,15 +215,15 @@ defmodule Igniter.Code.Keyword do
                if Igniter.Code.Tuple.tuple?(item) do
                  case Igniter.Code.Tuple.tuple_elem(item, 0) do
                    {:ok, first_elem} ->
-                     Common.node_matches_pattern?(first_elem, ^key)
+                     Common.nodes_equal?(first_elem, key)
 
                    :error ->
-                     false
+                     :error
                  end
                end
              end) do
           :error ->
-            {:ok, zipper}
+            :error
 
           {:ok, zipper} ->
             {:ok, zipper |> Zipper.remove()}

--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -400,8 +400,8 @@ defmodule Igniter.Project.Config do
              :config,
              3,
              fn function_call ->
-               Igniter.Code.Function.argument_matches_pattern?(function_call, 0, ^app_name) &&
-                 Igniter.Code.Function.argument_matches_pattern?(function_call, 1, ^config_item)
+               Igniter.Code.Function.argument_equals?(function_call, 0, app_name) &&
+                 Igniter.Code.Function.argument_equals?(function_call, 1, config_item)
              end
            ) do
         :error ->
@@ -418,8 +418,8 @@ defmodule Igniter.Project.Config do
              :config,
              3,
              fn function_call ->
-               Igniter.Code.Function.argument_matches_pattern?(function_call, 0, ^app_name) &&
-                 (Igniter.Code.Function.argument_matches_pattern?(function_call, 1, ^config_item) ||
+               Igniter.Code.Function.argument_equals?(function_call, 0, app_name) &&
+                 (Igniter.Code.Function.argument_equals?(function_call, 1, config_item) ||
                     Igniter.Code.Function.argument_matches_predicate?(
                       function_call,
                       1,
@@ -448,7 +448,7 @@ defmodule Igniter.Project.Config do
            :config,
            2,
            fn function_call ->
-             Igniter.Code.Function.argument_matches_pattern?(function_call, 0, ^app_name)
+             Igniter.Code.Function.argument_equals?(function_call, 0, app_name)
            end
          ) do
       :error ->


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR makes sure that `Keyword.remove_keyword_key/2` always returns `:error` when it fails. It also modifies `try_update_three_arg/5` and `try_update_two_arg/5` to use `argument_equals?` for keys instead of `argument_matches_pattern?`.