### PR TITLE
fix: escape injected code in Common.replace_code/2

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -272,7 +272,7 @@ defmodule Igniter.Code.Common do
 
   def replace_code(zipper, code) do
     # code = use_aliases(code, zipper)
-    Zipper.replace(zipper, code)
+    Zipper.replace(zipper, code |> Macro.to_string() |> Sourceror.parse_string!())
   end
 
   def extendable_block?({:__block__, meta, contents}) when is_list(contents) do

--- a/test/igniter/project/config_test.exs
+++ b/test/igniter/project/config_test.exs
@@ -234,6 +234,28 @@ defmodule Igniter.Project.ConfigTest do
              """
     end
 
+    @tag :regression
+    test "arbitrary data structures can be used as values" do
+      %{rewrite: rewrite} =
+        Igniter.new()
+        |> Igniter.create_new_elixir_file("config/fake.exs", """
+          import Config
+
+          config :level1, :level2, level3: [{"hello", "world"}]
+        """)
+        |> Igniter.Project.Config.configure("fake.exs", :level1, [:level2, :level3], [
+          {"hello1", "world1"}
+        ])
+
+      config_file = Rewrite.source!(rewrite, "config/fake.exs")
+
+      assert Source.get(config_file, :content) == """
+             import Config
+
+             config :level1, :level2, level3: [{"hello1", "world1"}]
+             """
+    end
+
     test "present values can be updated by updating map keys" do
       %{rewrite: rewrite} =
         Igniter.new()


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

In `Common.replace_code/2`, the code should be escaped before being injected. For example, when updating an existing config value to a list of string tuples, `Common.replace_code/2` will just inject it resulting in:
```elixir
[{"hello", "world"}]
```
instead of
```elixir
{:__block__,
  [
    trailing_comments: [],
    leading_comments: [],
    closing: [line: 1, column: 20],
    line: 1,
    column: 1
  ],
  [
    [
      {:__block__,
       [
         trailing_comments: [],
         leading_comments: [],
         closing: [line: 1, column: 19],
         line: 1,
         column: 2
       ],
       [
         {{:__block__,
           [
             trailing_comments: [],
             leading_comments: [],
             delimiter: "\"",
             line: 1,
             column: 3
           ], ["hello"]},
          {:__block__,
           [
             trailing_comments: [],
             leading_comments: [],
             delimiter: "\"",
             line: 1,
             column: 12
           ], ["world"]}}
       ]}
    ]
  ]}
```
and Sourceror then fails to put it back into string form resulting in
```
** (SyntaxError) invalid syntax found on nofile:9:42:
    error: syntax error before: '=>'
    │
  9 │       "hello" => "world",
    │               ^
    │
    └─ nofile:9:42
```

I think the fix is to just replace
```elixir
def replace_code(zipper, code) do
  # code = use_aliases(code, zipper)
  Zipper.replace(zipper, code)
end
```
with
```elixir
def replace_code(zipper, code) do
  # code = use_aliases(code, zipper)
  Zipper.replace(zipper, code |> Macro.to_string() |> Sourceror.parse_string!())
end
```

However, I don't know if this would break other things elsewhere 🤔 Or if it's something that should be handled in the default `updater` definitions:
```elixir
updater = opts[:updater] || fn zipper -> {:ok, Common.replace_code(zipper, value)} end
                                                                           ^
                                                                           here
```