### PR TITLE
fix: Accept an empty string when prompting

### DIFF
--- a/lib/igniter/util/io.ex
+++ b/lib/igniter/util/io.ex
@@ -4,7 +4,7 @@ defmodule Igniter.Util.IO do
   @doc "Prompts the user for yes or no, repeating the prompt until a satisfactory answer is given"
   def yes?(prompt) do
     case String.trim(Mix.shell().prompt(prompt <> " [Yn]")) do
-      yes when yes in ["y", "Y", "yes", "YES"] ->
+      yes when yes in ["y", "Y", "yes", "YES", ""] ->
         true
 
       no when no in ["n", "N", "no", "NO"] ->


### PR DESCRIPTION
The prompt `[Yn]` would indicate that `Y` is the default action, therefore we should accept an empty string as an indicator that the user wants us to continue.