### PR TITLE
docs: fix spelling in the README and writing generators documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mix igniter.new app_name --install ash --with phx.new --no-ecto
 
 ## Patterns
 
-Mix tasks built with igniter are both individually callable, _and_ composable. This means that tasks can call eachother, and also end users can create and customize their own generators composing existing tasks.
+Mix tasks built with igniter are both individually callable, _and_ composable. This means that tasks can call each other, and also end users can create and customize their own generators composing existing tasks.
 
 ### Installers
 

--- a/documentation/writing-generators.md
+++ b/documentation/writing-generators.md
@@ -87,7 +87,7 @@ It is not possible to prevent this from happening for all combinations of invoca
 
 Setting this group performs two functions:
 
-1. any tasks that share a group with eachother will be assumed that the same flag has the same meaning. That way,
+1. any tasks that share a group with each other will be assumed that the same flag has the same meaning. That way,
    users don't have to disambiguate when calling `mix igniter.install yourthing1 yourthing2 --option`, because it is assumed
    to have the same meaning.
 2. it can provide a shorter/semantic name to type, i.e instead of `--ash-authentication-phoenix.install.domain` it could be just `--ash.domain`.


### PR DESCRIPTION
Changed "eachother" to "each other" in README.md and the "Writing Generators" documentation.