### PR TITLE
improvement: resolve project app names set using a module attribute

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -171,6 +171,8 @@ defmodule Igniter.Code.Common do
   """
   @spec expand_literal(Zipper.t()) :: {:ok, any()} | :error
   def expand_literal(zipper) do
+    zipper = maybe_move_to_single_child_block(zipper)
+
     quoted_literal? =
       case zipper.node do
         {:__block__, _, _} = value ->

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -188,7 +188,13 @@ defmodule Igniter.Code.Common do
     else
       case current_env(zipper) do
         {:ok, env} ->
-          {:ok, Macro.expand_literals(zipper.node, env)}
+          expanded = Macro.expand_literals(zipper.node, env)
+
+          if Macro.quoted_literal?(expanded) do
+            {:ok, expanded}
+          else
+            :error
+          end
 
         _ ->
           :error

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -338,6 +338,21 @@ defmodule Igniter.Code.CommonTest do
                end)
     end
 
+    test "can match the first node tested" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+
+      assert {:ok, %Zipper{node: {:__block__, _, [0]}}} =
+               Common.move_right(zipper, fn
+                 %Zipper{node: {:__block__, _, [0]}} -> true
+                 _ -> false
+               end)
+    end
+
     test "returns :error if the predicate never matches" do
       zipper =
         "[0, 1, 2, 3]"
@@ -385,6 +400,22 @@ defmodule Igniter.Code.CommonTest do
       assert {:ok, %Zipper{node: {:__block__, _, [0]}}} =
                Common.move_left(zipper, fn
                  %Zipper{node: {:__block__, _, [0]}} -> true
+                 _ -> false
+               end)
+    end
+
+    test "can match the first node tested" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+        |> Common.rightmost()
+
+      assert {:ok, %Zipper{node: {:__block__, _, [3]}}} =
+               Common.move_left(zipper, fn
+                 %Zipper{node: {:__block__, _, [3]}} -> true
                  _ -> false
                end)
     end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -492,4 +492,25 @@ defmodule Igniter.Code.CommonTest do
       assert Common.move_upwards(zipper, 5) == :error
     end
   end
+
+  describe "expand_literal/1" do
+    test "it resolves basic literals" do
+      assert {:ok, :literal} = :literal |> Zipper.zip() |> Igniter.Code.Common.expand_literal()
+    end
+
+    test "it resolves literals that are the single child of a :__block__" do
+      assert {:ok, :literal} =
+               {:__block__, [], [:literal]}
+               |> Zipper.zip()
+               |> Igniter.Code.Common.expand_literal()
+    end
+
+    test "it returns an error when the node does not resolve to a literal" do
+      assert :error =
+               "@should_error"
+               |> Sourceror.parse_string!()
+               |> Zipper.zip()
+               |> Igniter.Code.Common.expand_literal()
+    end
+  end
 end

--- a/test/igniter/project/application_test.exs
+++ b/test/igniter/project/application_test.exs
@@ -173,4 +173,92 @@ defmodule Igniter.Project.ApplicationTest do
       """)
     end
   end
+
+  describe "app_name/1" do
+    test "it returns the application name when it's an atom literal" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                [
+                  app: :igniter_test
+                ]
+              end
+            end
+            """
+          }
+        )
+
+      assert Igniter.Project.Application.app_name(igniter) == :igniter_test
+    end
+
+    test "it returns the application name when it's a module attribute" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              @app :igniter_test
+
+              def project do
+                [
+                  app: @app
+                ]
+              end
+            end
+            """
+          }
+        )
+
+      assert Igniter.Project.Application.app_name(igniter) == :igniter_test
+    end
+
+    test "it raises if the application name can't be resolved" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                [
+                  app: app_name()
+                ]
+              end
+            end
+            """
+          }
+        )
+
+      assert_raise RuntimeError, fn -> Igniter.Project.Application.app_name(igniter) end
+
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                [
+                  app: @app
+                ]
+              end
+
+              @app :igniter_test
+            end
+            """
+          }
+        )
+
+      assert_raise RuntimeError, fn -> Igniter.Project.Application.app_name(igniter) end
+    end
+  end
 end


### PR DESCRIPTION
This PR also fixes two bugs in `Common.expand_literal/1`. Previously, the following would be returned:

```elixir
iex(1)> ":foo" |> Sourceror.parse_string!() |> Sourceror.Zipper.zip() |> Igniter.Code.Common.expand_literal()
{:ok, {:__block__, [trailing_comments: [], leading_comments: [], line: 1, column: 1], [:foo]}}
iex(2)> "@foo" |> Sourceror.parse_string!() |> Sourceror.Zipper.zip() |> Igniter.Code.Common.expand_literal()
{:ok,
 {:@, [trailing_comments: [], leading_comments: [], line: 1, column: 1],
  [{:foo, [trailing_comments: [], leading_comments: [], line: 1, column: 2], nil}]}}
```

With this PR:

```elixir
iex(1)> ":foo" |> Sourceror.parse_string!() |> Sourceror.Zipper.zip() |> Igniter.Code.Common.expand_literal()
{:ok, :foo}
iex(2)> "@foo" |> Sourceror.parse_string!() |> Sourceror.Zipper.zip() |> Igniter.Code.Common.expand_literal()
:error
```

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
