### PR TITLE
`Igniter.Code.Common`: Support integer argument in `move_right/2` and `move_upwards/2` and add `move_left/2`

### DIFF
--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -632,7 +632,7 @@ defmodule Igniter.Code.Function do
 
                 zipper ->
                   zipper
-                  |> Common.nth_right(index)
+                  |> Common.move_right(index)
                   |> case do
                     :error ->
                       :error
@@ -652,7 +652,7 @@ defmodule Igniter.Code.Function do
 
           zipper ->
             zipper
-            |> Common.nth_right(index)
+            |> Common.move_right(index)
             |> case do
               :error ->
                 :error
@@ -701,7 +701,7 @@ defmodule Igniter.Code.Function do
 
                 zipper ->
                   zipper
-                  |> Common.nth_right(index)
+                  |> Common.move_right(index)
                   |> case do
                     :error ->
                       :error
@@ -730,7 +730,7 @@ defmodule Igniter.Code.Function do
 
           zipper ->
             zipper
-            |> Common.nth_right(index + offset)
+            |> Common.move_right(index + offset)
             |> case do
               :error ->
                 :error
@@ -808,7 +808,7 @@ defmodule Igniter.Code.Function do
           {{:., _, [_mod, name]}, _, args} when is_atom(name) and is_list(args) ->
             zipper
             |> Zipper.down()
-            |> Common.nth_right(index + 1)
+            |> Common.move_right(index + 1)
             |> case do
               :error ->
                 false
@@ -828,7 +828,7 @@ defmodule Igniter.Code.Function do
 
               zipper ->
                 zipper
-                |> Common.nth_right(index)
+                |> Common.move_right(index)
                 |> case do
                   :error ->
                     false

--- a/lib/igniter/code/list.ex
+++ b/lib/igniter/code/list.ex
@@ -149,7 +149,7 @@ defmodule Igniter.Code.List do
         zipper
         |> Igniter.Code.Common.maybe_move_to_single_child_block()
         |> Zipper.down()
-        |> Common.nth_right(index)
+        |> Common.move_right(index)
         |> case do
           :error ->
             :error

--- a/lib/igniter/code/tuple.ex
+++ b/lib/igniter/code/tuple.ex
@@ -52,7 +52,7 @@ defmodule Igniter.Code.Tuple do
     item
     |> Common.maybe_move_to_single_child_block()
     |> Zipper.down()
-    |> Common.nth_right(elem)
+    |> Common.move_right(elem)
     |> case do
       {:ok, nth} ->
         {:ok, Common.maybe_move_to_single_child_block(nth)}

--- a/lib/mix/tasks/igniter.upgrade_igniter.ex
+++ b/lib/mix/tasks/igniter.upgrade_igniter.ex
@@ -42,7 +42,8 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
     upgrades =
       %{
         "0.3.66" => [&code_module_parse_to_project_module_parse/2],
-        "0.3.71" => [&code_module_parse_to_project_module_parse/2]
+        "0.3.71" => [&code_module_parse_to_project_module_parse/2],
+        "0.3.76" => [&code_common_nth_right_to_move_right/2]
       }
 
     # For each version that requires a change, add it to this map
@@ -60,7 +61,19 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
       arity: 1
     )
     |> Igniter.add_notice(
-      "Igniter.Code.Module.parse/1 was deprecated in favor of `Igniter.Project.Module.parse/1"
+      "Igniter.Code.Module.parse/1 was deprecated in favor of Igniter.Project.Module.parse/1"
+    )
+  end
+
+  defp code_common_nth_right_to_move_right(igniter, _opts) do
+    igniter
+    |> Igniter.Refactors.Rename.rename_function(
+      {Igniter.Code.Common, :nth_right},
+      {Igniter.Code.Common, :move_right},
+      arity: 2
+    )
+    |> Igniter.add_notice(
+      "Igniter.Code.Common.nth_right/2 was deprecated in favor of Igniter.Code.Common.move_right/2"
     )
   end
 end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -372,6 +372,60 @@ defmodule Igniter.Code.CommonTest do
     end
   end
 
+  describe "move_left/2" do
+    test "moves a zipper to the left until a predicate matches" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+        |> Common.rightmost()
+
+      assert {:ok, %Zipper{node: {:__block__, _, [0]}}} =
+               Common.move_left(zipper, fn
+                 %Zipper{node: {:__block__, _, [0]}} -> true
+                 _ -> false
+               end)
+    end
+
+    test "returns :error if the predicate never matches" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+        |> Common.rightmost()
+
+      assert Common.move_left(zipper, fn _ -> false end) == :error
+    end
+
+    test "moves a zipper to the left a given number of times" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+        |> Common.rightmost()
+
+      assert {:ok, %Zipper{node: {:__block__, _, [0]}}} = Common.move_left(zipper, 3)
+    end
+
+    test "returns :error if zipper cannot be moved right a given number of times" do
+      zipper =
+        "[0, 1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.down()
+        |> Zipper.down()
+        |> Common.rightmost()
+
+      assert Common.move_left(zipper, 4) == :error
+    end
+  end
+
   describe "move_upwards/2" do
     test "moves a zipper upwards until a predicate matches" do
       {:ok, zipper} =


### PR DESCRIPTION
This PR implements #112, if accepted.

Note: If #111 is merged first, this PR should be rebased to replace a [private function](https://github.com/ash-project/igniter/pull/111/files#diff-7a0262dc445950a410b05838f4415a4532f854ceebf504cacd6b9c0280000ad6R92-R94) used there with a call to `Igniter.Code.Common.move_upwards(zipper, 4)`. If this PR is merged first, #111 can be rebased instead.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
