### PR TITLE
improvement: add `Igniter.Test.diff/2`

### DIFF
--- a/lib/igniter/test.ex
+++ b/lib/igniter/test.ex
@@ -60,7 +60,7 @@ defmodule Igniter.Test do
         IO.puts("#{prefix}No changes!")
 
       diff ->
-        prefix = if label = "", do: "", else: "#{label}:\n\n"
+        prefix = if label == "", do: "", else: "#{label}:\n\n"
         IO.puts("#{prefix}#{diff}")
     end
 


### PR DESCRIPTION
I found myself writing [some tests](https://github.com/zachallaun/mneme/blob/main/test/mix/tasks/mneme.install_test.exs) where I wanted the diff as a string, but couldn't use `capture_io` and `Igniter.Test.puts_diff/2` because it included terminal escape codes for color.

This PR adds `Igniter.Test.diff/2` to support such a case.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
