### PR TITLE
`Igniter.Code.Common.replace_code/2`: Don't leave zipper at parent when extending blocks

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -491,7 +491,13 @@ defmodule Igniter.Code.Common do
       {head, tail} =
         Enum.split(upwards_code, index)
 
-      Zipper.replace(upwards, {:__block__, [], head ++ to_insert ++ Enum.drop(tail, 1)})
+      {:ok, zipper} =
+        upwards
+        |> Zipper.replace({:__block__, [], head ++ to_insert ++ Enum.drop(tail, 1)})
+        |> Zipper.down()
+        |> move_right(index)
+
+      zipper
     else
       _ ->
         with nil <- Zipper.up(zipper),

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -468,95 +468,48 @@ defmodule Igniter.Code.Common do
       v
   end
 
-  def replace_code(zipper, code) when is_binary(code) do
+  def replace_code(%Zipper{} = zipper, code) when is_binary(code) do
     replace_code(zipper, Sourceror.parse_string!(code))
   end
 
-  def replace_code(zipper, new_code) do
+  def replace_code(%Zipper{} = zipper, new_code) do
     new_code = use_aliases(new_code, zipper)
 
-    with upwards when not is_nil(upwards) <- Zipper.up(zipper),
-         {:__block__, _, upwards_code} <- upwards.node,
-         true <- extendable_block?(upwards.node) do
-      index = Enum.count(zipper.path.left || [])
+    if extendable_block?(new_code) and in_extendable_block?(zipper) do
+      at_supertree_root? = Zipper.up(zipper) == nil and !!zipper.supertree
+      zipper = if at_supertree_root?, do: supertree(zipper), else: zipper
 
-      to_insert =
-        if extendable_block?(new_code) do
-          {:__block__, _, new_code} = new_code
-          new_code
-        else
-          [new_code]
-        end
+      {:__block__, _, [new_code_head | new_code_tail]} = new_code
 
-      {head, tail} =
-        Enum.split(upwards_code, index)
+      zipper =
+        new_code_tail
+        |> Enum.reverse()
+        |> Enum.reduce(zipper, &Zipper.insert_right(&2, &1))
+        |> replace_node(new_code_head)
 
-      {:ok, zipper} =
-        upwards
-        |> Zipper.replace({:__block__, [], head ++ to_insert ++ Enum.drop(tail, 1)})
-        |> Zipper.down()
-        |> move_right(index)
-
-      zipper
+      if at_supertree_root?, do: Zipper.subtree(zipper), else: zipper
     else
-      _ ->
-        with nil <- Zipper.up(zipper),
-             supertree when not is_nil(supertree) <- zipper.supertree,
-             super_upwards when not is_nil(super_upwards) <- Zipper.up(supertree),
-             true <- extendable_block?(super_upwards.node),
-             {:__block__, _, upwards_code} <- super_upwards.node do
-          index = Enum.count(zipper.supertree.path.left || [])
+      replace_node(zipper, new_code)
+    end
+  end
 
-          to_insert =
-            if extendable_block?(new_code) do
-              {:__block__, _, new_code} = new_code
-              new_code
-            else
-              [new_code]
-            end
+  defp replace_node(zipper, new_code) do
+    new_code =
+      with true <- multi_element_pipe?(zipper),
+           {call, meta, [first_arg | rest]} when call != :|> <- new_code,
+           {:ok, rewritten} <- rewrite_pipe(call, meta, first_arg, rest) do
+        rewritten
+      else
+        _ ->
+          new_code
+      end
 
-          {head, tail} =
-            Enum.split(upwards_code, index)
+    case {zipper.node, new_code} do
+      {{_, meta, _}, {new_call, _, new_children}} ->
+        Zipper.replace(zipper, {new_call, meta, new_children})
 
-          new_super_upwards =
-            Zipper.replace(
-              super_upwards,
-              {:__block__, [], head ++ to_insert ++ tl(tail)}
-            )
-
-          %{
-            zipper
-            | supertree: %{
-                zipper.supertree
-                | path: %{
-                    zipper.supertree.path
-                    | parent: new_super_upwards,
-                      left: zipper.supertree.path.left,
-                      right: tl(to_insert) ++ zipper.supertree.path.right
-                  }
-              },
-              node: List.first(to_insert)
-          }
-        else
-          _ ->
-            new_code =
-              with true <- multi_element_pipe?(zipper),
-                   {call, meta, [first_arg | rest]} when call != :|> <- new_code,
-                   {:ok, rewritten} <- rewrite_pipe(call, meta, first_arg, rest) do
-                rewritten
-              else
-                _ ->
-                  new_code
-              end
-
-            case {zipper.node, new_code} do
-              {{_, meta, _}, {new_call, _, new_children}} ->
-                Zipper.replace(zipper, {new_call, meta, new_children})
-
-              {_node, _new_node} ->
-                Zipper.replace(zipper, new_code)
-            end
-        end
+      {_node, _new_node} ->
+        Zipper.replace(zipper, new_code)
     end
   end
 
@@ -589,6 +542,15 @@ defmodule Igniter.Code.Common do
   end
 
   def extendable_block?(_), do: false
+
+  defp in_extendable_block?(%Zipper{} = zipper) do
+    case Zipper.up(zipper) do
+      %Zipper{} = zipper -> extendable_block?(zipper)
+      nil -> in_extendable_block?(zipper.supertree)
+    end
+  end
+
+  defp in_extendable_block?(nil), do: false
 
   @doc """
   Replaces full module names in `new_code` with any aliases for that
@@ -1197,4 +1159,12 @@ defmodule Igniter.Code.Common do
 
   defp into(%Zipper{path: nil} = zipper, %Zipper{path: path, supertree: supertree}),
     do: %{zipper | path: path, supertree: supertree}
+
+  defp supertree(%Zipper{supertree: supertree} = zipper) when not is_nil(supertree) do
+    zipper
+    |> Zipper.top()
+    |> into(supertree)
+  end
+
+  defp supertree(_), do: nil
 end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -557,10 +557,12 @@ defmodule Igniter.Code.CommonTest do
       expected = "[1, :replaced, 3]"
 
       replaced = Common.replace_code(zipper, ":replaced")
+      refute replaced.supertree
       assert {:__block__, _, [:replaced]} = replaced.node
       assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
 
       subtree_replaced = zipper |> Zipper.subtree() |> Common.replace_code(":replaced")
+      assert subtree_replaced.supertree
       assert {:__block__, _, [:replaced]} = subtree_replaced.node
       assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
     end
@@ -587,10 +589,12 @@ defmodule Igniter.Code.CommonTest do
       """
 
       replaced = Common.replace_code(zipper, "replaced()")
+      refute replaced.supertree
       assert {:replaced, _, []} = replaced.node
       assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
 
       subtree_replaced = zipper |> Zipper.subtree() |> Common.replace_code("replaced()")
+      assert subtree_replaced.supertree
       assert {:replaced, _, []} = subtree_replaced.node
       assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
     end
@@ -619,12 +623,14 @@ defmodule Igniter.Code.CommonTest do
         """
 
       replaced = zipper |> Common.replace_code("replaced1()\nreplaced2()\n")
+      refute replaced.supertree
       assert {:replaced1, _, []} = replaced.node
       assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
 
       subtree_replaced =
         zipper |> Zipper.subtree() |> Common.replace_code("replaced1()\nreplaced2()\n")
 
+      assert subtree_replaced.supertree
       assert {:replaced1, _, []} = replaced.node
       assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
     end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -587,9 +587,11 @@ defmodule Igniter.Code.CommonTest do
       """
 
       replaced = Common.replace_code(zipper, "replaced()")
+      assert {:replaced, _, []} = replaced.node
       assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
 
       subtree_replaced = zipper |> Zipper.subtree() |> Common.replace_code("replaced()")
+      assert {:replaced, _, []} = subtree_replaced.node
       assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
     end
 
@@ -617,11 +619,13 @@ defmodule Igniter.Code.CommonTest do
         """
 
       replaced = zipper |> Common.replace_code("replaced1()\nreplaced2()\n")
+      assert {:replaced1, _, []} = replaced.node
       assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
 
       subtree_replaced =
         zipper |> Zipper.subtree() |> Common.replace_code("replaced1()\nreplaced2()\n")
 
+      assert {:replaced1, _, []} = replaced.node
       assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
     end
   end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -544,4 +544,85 @@ defmodule Igniter.Code.CommonTest do
                |> Igniter.Code.Common.expand_literal()
     end
   end
+
+  describe "replace_code/1" do
+    test "replaces simple values" do
+      zipper =
+        "[1, 2, 3]"
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.search_pattern("2")
+        |> Common.replace_code(":replaced")
+
+      expected = "[1, :replaced, 3]"
+
+      replaced = Common.replace_code(zipper, ":replaced")
+      assert {:__block__, _, [:replaced]} = replaced.node
+      assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+
+      subtree_replaced = zipper |> Zipper.subtree() |> Common.replace_code(":replaced")
+      assert {:__block__, _, [:replaced]} = subtree_replaced.node
+      assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+    end
+
+    test "replaces in blocks" do
+      zipper =
+        """
+        block do
+          one()
+          two()
+          three()
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.search_pattern("two()")
+
+      expected = """
+      block do
+        one()
+        replaced()
+        three()
+      end\
+      """
+
+      replaced = Common.replace_code(zipper, "replaced()")
+      assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+
+      subtree_replaced = zipper |> Zipper.subtree() |> Common.replace_code("replaced()")
+      assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+    end
+
+    test "extends in blocks" do
+      zipper =
+        """
+        block do
+          one()
+          two()
+          three()
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.search_pattern("two()")
+
+      expected =
+        """
+        block do
+          one()
+          replaced1()
+          replaced2()
+          three()
+        end\
+        """
+
+      replaced = zipper |> Common.replace_code("replaced1()\nreplaced2()\n")
+      assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+
+      subtree_replaced =
+        zipper |> Zipper.subtree() |> Common.replace_code("replaced1()\nreplaced2()\n")
+
+      assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+    end
+  end
 end


### PR DESCRIPTION
While working on something else, I noticed that `replace_code/2` would leave the zipper at the parent block in many cases. Here's an example of a test that fails on main:

```elixir
  test "replaces in blocks" do
    zipper =
      """
      block do
        one()
        two()
        three()
      end
      """
      |> Sourceror.parse_string!()
      |> Zipper.zip()
      |> Zipper.search_pattern("two()")

    expected = """
    block do
      one()
      replaced()
      three()
    end\
    """

    replaced = Common.replace_code(zipper, "replaced()")
    assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
    assert {:replaced, _, []} = replaced.node
  end
```

The first assertion will succeed, but the second will fail, because `replaced.node` is now the block containing the three calls.

This PR fixes that bug and additionally refactors `replace_code/2`. I'd suggest reviewing commits in order: the first commit adds passing tests, the second commit adds failing assertions and fixes the bug, and the third commit refactors the function.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
