### PR TITLE
Parse `argv` by default and store in `Igniter` struct (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,16 @@ To create your generator, use `mix igniter.gen.task <your_package>.task.name`
 defmodule Mix.Tasks.MyApp.Gen.Resource do
   use Igniter.Mix.Task
 
-  def igniter(igniter, [resource | _] = argv) do
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    [resource | _] = igniter.args.argv
+
     resource = Igniter.Code.Module.parse(resource)
     my_special_thing = Module.concat([resource, SpecialThing])
     location = Igniter.Code.Module.proper_location(my_special_thing)
 
     igniter
-    |> Igniter.compose_task("ash.gen.resource", argv)
+    |> Igniter.compose_task("ash.gen.resource", igniter.args.argv)
     |> Igniter.Project.Module.create_module(my_special_thing, """
       # this is the special thing for #{inspect()}
     """)

--- a/documentation/writing-generators.md
+++ b/documentation/writing-generators.md
@@ -13,7 +13,10 @@ Since an example is worth a thousand words, lets take a look at an example that 
 defmodule Mix.Tasks.YourLib.Gen.YourThing do
   use Igniter.Mix.Task
 
-  def igniter(igniter, [module_name | _ ] = argv) do
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    [module_name | _] = igniter.args.argv
+
     module_name = Igniter.Code.Module.parse(module_name)
     path = Igniter.Code.Module.proper_location(module_name)
     app_name = Igniter.Project.Application.app_name(igniter)

--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -3,7 +3,16 @@ defmodule Igniter do
   Tools for generating and patching code into an Elixir project.
   """
 
-  defstruct [:rewrite, issues: [], tasks: [], warnings: [], notices: [], assigns: %{}, moves: %{}]
+  defstruct [
+    :rewrite,
+    issues: [],
+    tasks: [],
+    warnings: [],
+    notices: [],
+    assigns: %{},
+    moves: %{},
+    args: %Igniter.Mix.Task.Args{}
+  ]
 
   alias Sourceror.Zipper
 
@@ -14,7 +23,8 @@ defmodule Igniter do
           warnings: [String.t()],
           notices: [String.t()],
           assigns: map(),
-          moves: %{optional(String.t()) => String.t()}
+          moves: %{optional(String.t()) => String.t()},
+          args: Igniter.Mix.Task.Args.t()
         }
 
   @type zipper_updater :: (Zipper.t() -> {:ok, Zipper.t()} | {:error, String.t() | [String.t()]})
@@ -333,16 +343,17 @@ defmodule Igniter do
   Finds the `Igniter.Mix.Task` task by name and composes it (calls its `igniter/2`) into the current igniter.
   If the task doesn't exist, a fallback implementation may be provided as the last argument.
   """
-  def compose_task(igniter, task, argv \\ [], fallback \\ nil)
+  def compose_task(igniter, task, argv \\ nil, fallback \\ nil)
 
   def compose_task(igniter, task, argv, fallback) when is_atom(task) do
+    argv = argv || igniter.args.argv
     Code.ensure_compiled!(task)
 
-    if function_exported?(task, :igniter, 2) do
+    if function_exported?(task, :igniter, 1) or function_exported?(task, :igniter, 2) do
       if !task.supports_umbrella?() && Mix.Project.umbrella?() do
         add_issue(igniter, "Cannot run #{inspect(task)} in an umbrella project.")
       else
-        task.igniter(igniter, argv)
+        Igniter.Mix.Task.configure(igniter, task, argv)
       end
     else
       if is_function(fallback) do
@@ -361,6 +372,8 @@ defmodule Igniter do
   end
 
   def compose_task(igniter, task_name, argv, fallback) do
+    argv = argv || igniter.args.argv
+
     if igniter.issues == [] do
       task_name
       |> Mix.Task.get()

--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -382,7 +382,7 @@ defmodule Igniter do
           t,
           task :: String.t() | module(),
           argv :: list(String.t()) | nil,
-          fallback :: (t -> t) | (t, list(String.t()) -> t)
+          fallback :: (t -> t) | (t, list(String.t()) -> t) | nil
         ) :: t
   def compose_task(igniter, task, argv \\ nil, fallback \\ nil)
 

--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -391,7 +391,7 @@ defmodule Igniter do
 
     original_args = igniter.args
 
-    if function_exported?(task, :igniter, 1) or function_exported?(task, :igniter, 2) do
+    if Igniter.Mix.Task.igniter_task?(task) do
       if !task.supports_umbrella?() && Mix.Project.umbrella?() do
         add_issue(igniter, "Cannot run #{inspect(task)} in an umbrella project.")
       else

--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -396,7 +396,7 @@ defmodule Igniter do
         add_issue(igniter, "Cannot run #{inspect(task)} in an umbrella project.")
       else
         igniter
-        |> Igniter.Mix.Task.configure(task, argv || igniter.args.argv_flags)
+        |> Igniter.Mix.Task.configure_and_run(task, argv || igniter.args.argv_flags)
         |> Map.replace!(:args, original_args)
       end
     else

--- a/lib/igniter/upgrades/igniter.ex
+++ b/lib/igniter/upgrades/igniter.ex
@@ -1,0 +1,99 @@
+defmodule Igniter.Upgrades.Igniter do
+  @moduledoc false
+
+  alias Igniter.Code.Common
+  alias Igniter.Code.Function
+  alias Igniter.Code.Module
+  alias Sourceror.Zipper
+
+  require Common
+  require Function
+
+  @doc """
+  Rewrites deprecated `igniter/2` callback to `igniter/1` if the module
+  is an `Igniter.Mix.Task`.
+  """
+  @spec rewrite_deprecated_igniter_callback(Zipper.t()) :: {:ok, Zipper.t()} | :error
+  def rewrite_deprecated_igniter_callback(%Zipper{} = zipper) do
+    with {:ok, zipper} <- Module.move_to_module_using(zipper, [Igniter.Mix.Task]),
+         {:ok, zipper} <- Common.move_to_pattern(zipper, {:def, _, [{:igniter, _, [_, _]} | _]}) do
+      with :error <- remove_ignored_argv(zipper),
+           :error <- replace_generated_argv_usage(zipper) do
+        {:ok, zipper}
+      end
+    else
+      _ -> {:ok, zipper}
+    end
+  end
+
+  defp remove_ignored_argv(zipper) do
+    with {:ok, {argv_var, _, nil}} <- fetch_argv_arg(zipper),
+         "_" <> _ <- to_string(argv_var) do
+      remove_argv_arg(zipper)
+    else
+      _ -> :error
+    end
+  end
+
+  defp replace_generated_argv_usage(zipper) do
+    with {:ok, {:argv, _, nil}} <- fetch_argv_arg(zipper),
+         {:ok, zipper} <- remove_argv_arg(zipper),
+         {:ok, zipper} <- Common.move_to_do_block(zipper),
+         zipper <- Common.maybe_move_to_block(zipper),
+         true <- generated_argv_usage?(zipper) do
+      zipper =
+        zipper
+        |> Zipper.remove()
+        |> Zipper.next()
+        |> Common.replace_code("""
+        arguments = igniter.args.positional
+        options = igniter.args.options
+        argv = igniter.args.argv_flags
+        """)
+
+      {:ok, zipper}
+    else
+      _ -> :error
+    end
+  end
+
+  defp generated_argv_usage?(zipper) do
+    line_one_match? =
+      Function.function_call?(zipper, :=, 2) and
+        Function.argument_matches_pattern?(zipper, 0, {{:arguments, _, nil}, {:argv, _, nil}}) and
+        Function.argument_matches_predicate?(
+          zipper,
+          1,
+          &Common.node_matches_pattern?(&1, {:positional_args!, _, [{:argv, _, nil}]})
+        )
+
+    with true <- line_one_match?,
+         {:ok, zipper} <- Common.move_right(zipper, 1) do
+      Function.function_call?(zipper, :=, 2) and
+        Function.argument_matches_pattern?(zipper, 0, {:options, _, nil}) and
+        Function.argument_matches_predicate?(
+          zipper,
+          1,
+          &Common.node_matches_pattern?(&1, {:options!, _, [{:argv, _, nil}]})
+        )
+    else
+      _ -> false
+    end
+  end
+
+  defp remove_argv_arg(zipper) do
+    Common.within(zipper, fn zipper ->
+      with {:ok, argv} <- fetch_argv_arg(zipper),
+           {:ok, zipper} <- Common.move_to_pattern(zipper, ^argv) do
+        {:ok, Zipper.remove(zipper)}
+      end
+    end)
+  end
+
+  defp fetch_argv_arg(zipper) do
+    case zipper.node do
+      {:def, _, [{:igniter, _, [_, argv]} | _]} -> {:ok, argv}
+      _ -> :error
+    end
+  end
+end

--- a/lib/mix/task.ex
+++ b/lib/mix/task.ex
@@ -7,6 +7,11 @@ defmodule Igniter.Mix.Task do
   > A default `run/1` is implemented so you can directly run the task. Igniter never uses this function, so it is overridable.
   >
   > This enables your library to make use of the task for its own purposes if needed. An example would be if you wanted to implement an Igniter installer, but also have an `install` task for end-user consumption (e.g. `mix tailwind.install`).
+
+  ## Options and Arguments
+
+  Command line args are automatically parsed into `igniter.args` using the configuration returned
+  from `c:info/2`. See `Igniter.Mix.Task.Info` for more.
   """
 
   alias Igniter.Mix.Task.Info

--- a/lib/mix/task.ex
+++ b/lib/mix/task.ex
@@ -93,7 +93,7 @@ defmodule Igniter.Mix.Task do
           Igniter.Util.Info.validate!(argv, info, Mix.Task.task_name(__MODULE__))
 
         Igniter.new()
-        |> Igniter.Mix.Task.configure(__MODULE__, argv)
+        |> Igniter.Mix.Task.configure_and_run(__MODULE__, argv)
         |> Igniter.do_or_dry_run(opts)
       end
 
@@ -141,7 +141,7 @@ defmodule Igniter.Mix.Task do
   end
 
   @doc false
-  def configure(igniter, task_module, argv) do
+  def configure_and_run(igniter, task_module, argv) do
     case task_module.parse_argv(argv) do
       %Args{} = args ->
         igniter = %{igniter | args: args}

--- a/lib/mix/task.ex
+++ b/lib/mix/task.ex
@@ -369,4 +369,11 @@ defmodule Igniter.Mix.Task do
 
     "mix #{name} #{call}"
   end
+
+  @doc false
+  def igniter_task?(task) when is_atom(task) do
+    mix_task? = function_exported?(task, :run, 1)
+    igniter_task? = function_exported?(task, :igniter, 1) or function_exported?(task, :igniter, 2)
+    mix_task? and igniter_task?
+  end
 end

--- a/lib/mix/task/args.ex
+++ b/lib/mix/task/args.ex
@@ -3,10 +3,10 @@ defmodule Igniter.Mix.Task.Args do
   Command line arguments parsed when running an `Igniter.Mix.Task`.
   """
 
-  defstruct positional: [], options: [], argv_flags: [], argv: []
+  defstruct positional: %{}, options: [], argv_flags: [], argv: []
 
   @type t :: %__MODULE__{
-          positional: keyword(),
+          positional: %{atom() => term()},
           options: keyword(),
           argv_flags: list(String.t()),
           argv: list(String.t())

--- a/lib/mix/task/args.ex
+++ b/lib/mix/task/args.ex
@@ -1,0 +1,14 @@
+defmodule Igniter.Mix.Task.Args do
+  @moduledoc """
+  Command line arguments parsed when running an `Igniter.Mix.Task`.
+  """
+
+  defstruct positional: [], options: [], argv_flags: [], argv: []
+
+  @type t :: %__MODULE__{
+          positional: keyword(),
+          options: keyword(),
+          argv_flags: list(String.t()),
+          argv: list(String.t())
+        }
+end

--- a/lib/mix/task/args.ex
+++ b/lib/mix/task/args.ex
@@ -1,6 +1,10 @@
 defmodule Igniter.Mix.Task.Args do
   @moduledoc """
   Command line arguments parsed when running an `Igniter.Mix.Task`.
+
+  These args will usually be accessed through `igniter.args` when the
+  `c:Igniter.Mix.Task.igniter/1` callback is run. To learn more about how
+  they are parsed, see `Igniter.Mix.Task.Info`.
   """
 
   defstruct positional: %{}, options: [], argv_flags: [], argv: []

--- a/lib/mix/task/info.ex
+++ b/lib/mix/task/info.ex
@@ -20,16 +20,33 @@ defmodule Igniter.Mix.Task.Info do
 
   ## Options and Arguments
 
-  To get the options (values for flags specified by the schema), use the `positional_args!/1` and `options!/` macros,
-  like so:
+  Command line args are automatically parsed into `igniter.args` using this struct's configuration.
 
-  ```elixir
-  def igniter(igniter, argv) do
-    {arguments, argv} = positional_args!(argv)
-    options = options!(argv)
-    ...
-  end
-  ```
+      @impl Igniter.Mix.Task
+      def igniter(igniter) do
+        positional = igniter.args.positional
+        options = igniter.args.options
+      end
+
+  If you need to do custom validation or parsing, you can implement `c:Igniter.Mix.Task.parse_argv/1`
+  and return an `Igniter.Mix.Task.Args` struct. If helpful, the `positional_args!/1` and
+  `options!/1` macros can be used to parse positional arguments and options/flags using your
+  info configuration.
+
+      @impl Igniter.Mix.Task
+      def parse_argv(argv) do
+        {positional, argv_flags} = positional_args!(argv)
+        options = options!(argv_flags)
+
+        # custom validation or additional parsing
+
+        %Igniter.Mix.Task.Args{
+          argv: argv,
+          argv_flags: argv_flags,
+          positional: positional,
+          options: options
+        }
+      end
 
   ## Options
 

--- a/lib/mix/tasks/igniter.add_extension.ex
+++ b/lib/mix/tasks/igniter.add_extension.ex
@@ -26,8 +26,8 @@ defmodule Mix.Tasks.Igniter.AddExtension do
     }
   end
 
-  def igniter(igniter, argv) do
-    {%{extension: extension}, _argv} = positional_args!(argv)
+  def igniter(igniter) do
+    extension = igniter.args.positional.extension
 
     extension =
       if extension == "phoenix" do

--- a/lib/mix/tasks/igniter.gen.task.ex
+++ b/lib/mix/tasks/igniter.gen.task.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
 
       #{docs}
 
+      @impl Igniter.Mix.Task
       def info(_argv, _composing_task) do
         %Igniter.Mix.Task.Info{
           # Groups allow for overlapping arguments for tasks by the same author
@@ -109,7 +110,8 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
           # dependencies to add and call their associated installers, if they exist
           installs: [],
           # An example invocation
-          example: @example,#{only(opts, task_name)}
+          example: @example,
+          #{only(opts, task_name)}\
           # a list of positional arguments, i.e `[:file]`
           positional: #{positional(opts)},
           # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
@@ -117,7 +119,7 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
           composes: [],
           # `OptionParser` schema
           schema: [],
-          # Default values for the options in the `schema`.
+          # Default values for the options in the `schema`
           defaults: [],
           # CLI aliases
           aliases: [],
@@ -126,12 +128,8 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
         }
       end
 
-      def igniter(igniter, argv) do
-        # extract positional arguments according to `positional` above
-        {arguments, argv} = positional_args!(argv)
-        # extract options according to `schema` and `aliases` above
-        options = options!(argv)
-
+      @impl Igniter.Mix.Task
+      def igniter(igniter) do
         #{execute(opts, task_name)}
       end
     end
@@ -176,6 +174,7 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
       if Code.ensure_loaded?(Igniter) do
         use Igniter.Mix.Task
 
+        @impl Igniter.Mix.Task
         def info(_argv, _composing_task) do
           %Igniter.Mix.Task.Info{
             # Groups allow for overlapping arguments for tasks by the same author
@@ -186,7 +185,8 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
             # dependencies to add and call their associated installers, if they exist
             installs: [],
             # An example invocation
-            example: @example,#{only(opts, task_name)}
+            example: @example,
+            #{only(opts, task_name)}\
             # a list of positional arguments, i.e `[:file]`
             positional: #{positional(opts)},
             # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
@@ -194,7 +194,7 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
             composes: [],
             # `OptionParser` schema
             schema: [],
-            # Default values for the options in the `schema`.
+            # Default values for the options in the `schema`
             defaults: [],
             # CLI aliases
             aliases: [],
@@ -203,12 +203,8 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
           }
         end
 
-        def igniter(igniter, argv) do
-          # extract positional arguments according to `positional` above
-          {arguments, argv} = positional_args!(argv)
-          # extract options according to `schema` and `aliases` above
-          options = options!(argv)
-
+        @impl Igniter.Mix.Task
+        def igniter(igniter) do
           #{execute(opts, task_name)}
         end
       else
@@ -243,14 +239,17 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
   defp execute(opts, task_name) do
     if opts[:upgrade] do
       """
+      positional = igniter.args.positional
+      options = igniter.args.options
+
       upgrades = %{
-        # "0.1.1" -> [&change_foo_to_bar/2]
+        # "0.1.1" => [&change_foo_to_bar/2]
       }
       # For each version that requires a change, add it to this map
       # Each key is a version that points at a list of functions that take an
-      # igniter and options (i.e flags or other custom options).
+      # igniter and options (i.e. flags or other custom options).
       # See the upgrades guide for more.
-      Igniter.Upgrades.run(igniter, arguments.from, arguments.to, upgrades, custom_opts: options)
+      Igniter.Upgrades.run(igniter, positional.from, positional.to, upgrades, custom_opts: options)
       """
     else
       """

--- a/lib/mix/tasks/igniter.gen.task.ex
+++ b/lib/mix/tasks/igniter.gen.task.ex
@@ -32,9 +32,9 @@ defmodule Mix.Tasks.Igniter.Gen.Task do
     }
   end
 
-  def igniter(igniter, argv) do
-    {%{task_name: task_name}, argv} = positional_args!(argv)
-    options = options!(argv)
+  def igniter(igniter) do
+    task_name = igniter.args.positional.task_name
+    options = igniter.args.options
 
     options =
       if options[:upgrade] do

--- a/lib/mix/tasks/igniter.move_files.ex
+++ b/lib/mix/tasks/igniter.move_files.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Igniter.MoveFiles do
   @shortdoc @moduledoc
   use Igniter.Mix.Task
 
-  def igniter(igniter, _argv) do
+  def igniter(igniter) do
     Mix.shell().info("Finding all modules and determining proper locations...")
     Igniter.Project.Module.move_files(igniter, move_all?: true)
   end

--- a/lib/mix/tasks/igniter.refactor.rename_function.ex
+++ b/lib/mix/tasks/igniter.refactor.rename_function.ex
@@ -41,10 +41,9 @@ defmodule Mix.Tasks.Igniter.Refactor.RenameFunction do
     }
   end
 
-  def igniter(igniter, argv) do
-    # extract positional arguments according to `positional` above
-    {arguments, argv} = positional_args!(argv)
-    options = options!(argv)
+  def igniter(igniter) do
+    arguments = igniter.args.positional
+    options = igniter.args.options
 
     deprecate =
       case options[:deprecate] do

--- a/lib/mix/tasks/igniter.refactor.unless_to_if_not.ex
+++ b/lib/mix/tasks/igniter.refactor.unless_to_if_not.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Igniter.Refactor.UnlessToIfNot do
     }
   end
 
-  def igniter(igniter, _argv) do
+  def igniter(igniter) do
     Igniter.Refactors.Elixir.unless_to_if_not(igniter)
   end
 end

--- a/lib/mix/tasks/igniter.setup.ex
+++ b/lib/mix/tasks/igniter.setup.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Igniter.Setup do
   @shortdoc @moduledoc
   use Igniter.Mix.Task
 
-  def igniter(igniter, _argv) do
+  def igniter(igniter) do
     Igniter.Project.IgniterConfig.setup(igniter)
   end
 end

--- a/lib/mix/tasks/igniter.update_gettext.ex
+++ b/lib/mix/tasks/igniter.update_gettext.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Igniter.UpdateGettext do
     %Igniter.Mix.Task.Info{group: :igniter}
   end
 
-  def igniter(igniter, _argv) do
+  def igniter(igniter) do
     {igniter, modules} = find_use_gettext_modules(igniter)
 
     modules

--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -57,9 +57,9 @@ defmodule Mix.Tasks.Igniter.Upgrade do
     }
   end
 
-  def igniter(igniter, argv) do
-    {%{packages: packages}, argv} = positional_args!(argv)
-    options = options!(argv)
+  def igniter(igniter) do
+    packages = igniter.args.positional.packages
+    options = igniter.args.options
 
     options =
       if options[:git_ci] do
@@ -189,7 +189,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
       original_deps_info
       |> dep_changes_in_order(new_deps_info)
       |> Enum.reduce({igniter, []}, fn update, {igniter, missing} ->
-        case apply_updates(igniter, update, argv) do
+        case apply_updates(igniter, update) do
           {:ok, igniter} ->
             {igniter, missing}
 
@@ -265,7 +265,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
     end
   end
 
-  defp apply_updates(igniter, {package, from, to}, argv) do
+  defp apply_updates(igniter, {package, from, to}) do
     task =
       if package == :igniter do
         "igniter.upgrade_igniter"
@@ -275,7 +275,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
 
     with task when not is_nil(task) <- Mix.Task.get(task),
          true <- function_exported?(task, :info, 2) do
-      {:ok, task.igniter(igniter, [from, to] ++ argv)}
+      {:ok, task.igniter(igniter, [from, to] ++ igniter.args.argv_flags)}
     else
       _ ->
         {:missing, package}

--- a/lib/mix/tasks/igniter.upgrade_igniter.ex
+++ b/lib/mix/tasks/igniter.upgrade_igniter.ex
@@ -33,11 +33,9 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
     }
   end
 
-  def igniter(igniter, argv) do
-    # extract positional arguments according to `positional` above
-    {arguments, argv} = positional_args!(argv)
-    # extract options according to `schema` and `aliases` above
-    options = options!(argv)
+  def igniter(igniter) do
+    arguments = igniter.args.positional
+    options = igniter.args.options
 
     upgrades =
       %{

--- a/lib/mix/tasks/igniter.upgrade_igniter.ex
+++ b/lib/mix/tasks/igniter.upgrade_igniter.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
       installs: [],
       # An example invocation
       example: @example,
-
       # a list of positional arguments, i.e `[:file]`
       positional: [:from, :to],
       # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv
@@ -41,7 +40,8 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
       %{
         "0.3.66" => [&code_module_parse_to_project_module_parse/2],
         "0.3.71" => [&code_module_parse_to_project_module_parse/2],
-        "0.3.76" => [&code_common_nth_right_to_move_right/2]
+        "0.3.76" => [&code_common_nth_right_to_move_right/2],
+        "0.4.0" => [&igniter2_to_igniter1/2]
       }
 
     # For each version that requires a change, add it to this map
@@ -73,5 +73,11 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniter do
     |> Igniter.add_notice(
       "Igniter.Code.Common.nth_right/2 was deprecated in favor of Igniter.Code.Common.move_right/2"
     )
+  end
+
+  defp igniter2_to_igniter1(igniter, _opts) do
+    Igniter.update_all_elixir_files(igniter, fn zipper ->
+      Igniter.Upgrades.Igniter.rewrite_deprecated_igniter_callback(zipper)
+    end)
   end
 end

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -598,7 +598,7 @@ defmodule Igniter.Code.CommonTest do
     end
   end
 
-  describe "replace_code/1" do
+  describe "replace_code/2" do
     test "replaces simple values" do
       zipper =
         "[1, 2, 3]"
@@ -672,6 +672,42 @@ defmodule Igniter.Code.CommonTest do
           replaced1()
           replaced2()
           three()
+        end\
+        """
+
+      replaced = zipper |> Common.replace_code("replaced1()\nreplaced2()\n")
+      refute replaced.supertree
+      assert {:replaced1, _, []} = replaced.node
+      assert expected == replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+
+      subtree_replaced =
+        zipper |> Zipper.subtree() |> Common.replace_code("replaced1()\nreplaced2()\n")
+
+      assert subtree_replaced.supertree
+      assert {:replaced1, _, []} = replaced.node
+      assert expected == subtree_replaced |> Zipper.topmost_root() |> Sourceror.to_string()
+    end
+
+    test "keeps newlines" do
+      zipper =
+        """
+        block do
+          one()
+
+          two()
+        end
+        """
+        |> Sourceror.parse_string!()
+        |> Zipper.zip()
+        |> Zipper.search_pattern("one()")
+
+      expected =
+        """
+        block do
+          replaced1()
+          replaced2()
+
+          two()
         end\
         """
 

--- a/test/igniter/mix/task_test.exs
+++ b/test/igniter/mix/task_test.exs
@@ -19,12 +19,9 @@ defmodule Igniter.Mix.TaskTest do
       }
     end
 
-    def igniter(igniter, argv) do
-      options = options!(argv)
-      {args, _argv} = positional_args!(argv)
-
-      send(self(), {:args, args})
-      send(self(), {:options, options})
+    def igniter(igniter) do
+      send(self(), {:args, igniter.args.positional})
+      send(self(), {:options, igniter.args.options})
       igniter
     end
   end
@@ -40,14 +37,14 @@ defmodule Igniter.Mix.TaskTest do
   end
 
   test "it parses options" do
-    ExampleTask.igniter(Igniter.new(), ["foo", "--option", "foo"])
+    ExampleTask.run(["foo", "--option", "foo"])
     assert_received {:options, options}
     assert options[:option] == "foo"
     assert_received {:args, %{a: "foo"}}
   end
 
   test "it parses rest options" do
-    ExampleTask.igniter(Igniter.new(), ["foo", "--option", "foo"])
+    ExampleTask.run(["foo", "--option", "foo"])
     assert_received {:options, options}
     assert options[:option] == "foo"
     assert_received {:args, %{a: "foo"}}
@@ -72,7 +69,7 @@ defmodule Igniter.Mix.TaskTest do
         }
       end
 
-      def igniter(igniter, _argv) do
+      def igniter(igniter) do
         igniter
       end
     end
@@ -92,7 +89,7 @@ defmodule Igniter.Mix.TaskTest do
         }
       end
 
-      def igniter(igniter, _argv) do
+      def igniter(igniter) do
         igniter
       end
     end
@@ -109,7 +106,7 @@ defmodule Igniter.Mix.TaskTest do
         }
       end
 
-      def igniter(igniter, _argv) do
+      def igniter(igniter) do
         igniter
       end
     end
@@ -133,7 +130,7 @@ defmodule Igniter.Mix.TaskTest do
         }
       end
 
-      def igniter(igniter, _argv) do
+      def igniter(igniter) do
         igniter
       end
     end
@@ -157,9 +154,8 @@ defmodule Igniter.Mix.TaskTest do
         }
       end
 
-      def igniter(igniter, argv) do
-        {_, argv} = positional_args!(argv)
-        send(self(), {:options, options!(argv)})
+      def igniter(igniter) do
+        send(self(), {:options, igniter.args.options})
         igniter
       end
     end
@@ -219,6 +215,64 @@ defmodule Igniter.Mix.TaskTest do
 
       assert_received {:options, options}
       assert options[:other] == "foo"
+    end
+  end
+
+  describe "igniter/2 deprecation" do
+    defp define_module do
+      original_opts = Code.compiler_options()
+      Code.put_compiler_option(:ignore_module_conflict, true)
+
+      {:module, module, _, _} =
+        defmodule ExampleTaskWithIgniter1AndIgniter2 do
+          use Igniter.Mix.Task
+
+          def info(_argv, _parent) do
+            %Igniter.Mix.Task.Info{}
+          end
+
+          def igniter(igniter) do
+            send(self(), {:igniter1, igniter.args})
+            igniter
+          end
+
+          def igniter(igniter, _argv) do
+            send(self(), :igniter2)
+            igniter
+          end
+        end
+
+      Code.compiler_options(original_opts)
+
+      module
+    end
+
+    test "igniter/2 is not called if igniter/1 is defined" do
+      ExUnit.CaptureLog.capture_log(fn ->
+        task = define_module()
+        task.run([])
+      end)
+
+      assert_receive {:igniter1, %Igniter.Mix.Task.Args{}}
+      refute_receive :igniter2
+    end
+
+    test "warning is logged if both igniter/1 and igniter/2 are defined" do
+      {module, logged} =
+        ExUnit.CaptureLog.with_log(fn ->
+          define_module()
+        end)
+
+      assert logged =~ inspect(module)
+      assert logged =~ "defines both igniter/1 and igniter/2"
+    end
+
+    test "compilation error is raised if neither igniter/1 nor igniter/2 are defined" do
+      assert_raise CompileError, ~r"must define either igniter/1 or igniter/2", fn ->
+        defmodule ShouldRaise do
+          use Igniter.Mix.Task
+        end
+      end
     end
   end
 end

--- a/test/mix/tasks/igniter.upgrade_igniter_test.exs
+++ b/test/mix/tasks/igniter.upgrade_igniter_test.exs
@@ -81,4 +81,25 @@ defmodule Mix.Tasks.Igniter.UpgradeIgniterTest do
       |    igniter
     """)
   end
+
+  test "doesn't upgrade igniter/2 when generated argv usage was modified" do
+    test_project(
+      files: %{
+        "lib/mix/tasks/my_task.ex" => """
+        defmodule Mix.Tasks.MyTask do
+          use Igniter.Mix.Task
+
+          def igniter(igniter, argv) do
+            foo = {arguments, argv} = positional_args!(argv)
+            bar = options = options!(argv)
+
+            igniter
+          end
+        end
+        """
+      }
+    )
+    |> Igniter.compose_task("igniter.upgrade_igniter", ["0.3.76", "0.4.0"])
+    |> assert_unchanged()
+  end
 end

--- a/test/mix/tasks/igniter.upgrade_igniter_test.exs
+++ b/test/mix/tasks/igniter.upgrade_igniter_test.exs
@@ -1,0 +1,84 @@
+defmodule Mix.Tasks.Igniter.UpgradeIgniterTest do
+  use ExUnit.Case
+  import Igniter.Test
+
+  describe "igniter/2 -> igniter/1 upgrade" do
+    test "does not affect non-Igniter.Mix.Task modules" do
+      test_project(
+        files: %{
+          "lib/mix/tasks/my_task.ex" => """
+          defmodule Mix.Tasks.MyTask do
+            use Mix.Task
+
+            def igniter(igniter, _argv) do
+              igniter
+            end
+
+            def run(_argv) do
+              :ok
+            end
+          end
+          """
+        }
+      )
+      |> Igniter.compose_task("igniter.upgrade_igniter", ["0.3.76", "0.4.0"])
+      |> assert_unchanged("lib/mix/tasks/my_task.ex")
+    end
+  end
+
+  test "upgrades igniter/2 when argv is ignored" do
+    test_project(
+      files: %{
+        "lib/mix/tasks/my_task.ex" => """
+        defmodule Mix.Tasks.MyTask do
+          use Igniter.Mix.Task
+
+          def igniter(igniter, _argv) do
+            igniter
+          end
+        end
+        """
+      }
+    )
+    |> Igniter.compose_task("igniter.upgrade_igniter", ["0.3.76", "0.4.0"])
+    |> assert_has_patch("lib/mix/tasks/my_task.ex", """
+    - |  def igniter(igniter, _argv) do
+    + |  def igniter(igniter) do
+    """)
+  end
+
+  test "upgrades igniter/2 when argv is used as generated" do
+    test_project(
+      files: %{
+        "lib/mix/tasks/my_task.ex" => """
+        defmodule Mix.Tasks.MyTask do
+          use Igniter.Mix.Task
+
+          def igniter(igniter, argv) do
+            # extract positional arguments according to `positional` above
+            {arguments, argv} = positional_args!(argv)
+            # extract options according to `schema` and `aliases` above
+            options = options!(argv)
+
+            igniter
+          end
+        end
+        """
+      }
+    )
+    |> Igniter.compose_task("igniter.upgrade_igniter", ["0.3.76", "0.4.0"])
+    |> assert_has_patch("lib/mix/tasks/my_task.ex", """
+    - |  def igniter(igniter, argv) do
+    - |    # extract positional arguments according to `positional` above
+    - |    {arguments, argv} = positional_args!(argv)
+    - |    # extract options according to `schema` and `aliases` above
+    - |    options = options!(argv)
+    + |  def igniter(igniter) do
+    + |    arguments = igniter.args.positional
+    + |    options = igniter.args.options
+    + |    argv = igniter.args.argv_flags
+      |
+      |    igniter
+    """)
+  end
+end


### PR DESCRIPTION
Work in progress implementation of #126.

- [x] Add `%Igniter.Mix.Task.Args{}` struct and add an `:args` field to `%Igniter{}`
- [x] Introduce an optional `parse_argv/2` callback to the `Igniter.Mix.Task` behaviour
- [x] Update the task runner to parse args, call `igniter/1` if available, and fall back to `igniter/2`
- [x] Update task composition to parse args and set the `:args` field prior to running a composed task
- [x] Warn if both `igniter/1` and `igniter/2` are defined
- [x] Raise if neither `igniter/1` nor `igniter/2` are defined
- [x] Bug: `compile_task/4` needs to reset the igniter's args after running the composed task
- [x] Update tests
- [x] Update Igniter tasks
- [x] Update generators
- [x] Update docs and guides
- [x] Update `mix igniter.upgrade_igniter` to automatically move `igniter/2` to `igniter/1` for simple cases

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
