### PR TITLE
Fix elixir forum link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule Igniter.MixProject do
         GitHub: "https://github.com/ash-project/igniter",
         Discord: "https://discord.gg/HTHRaaVPUc",
         Website: "https://ash-hq.org",
-        Forum: "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum"
+        Forum: "https://elixirforum.com/c/ash-framework-forum/"
       }
     ]
   end


### PR DESCRIPTION
The link on https://hex.pm/packages/igniter was going to "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum" which is a broken link

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
