### PR TITLE
Add `priv_dir` functions to return priv directory

### DIFF
--- a/lib/igniter/project/application.ex
+++ b/lib/igniter/project/application.ex
@@ -78,6 +78,13 @@ defmodule Igniter.Project.Application do
     end
   end
 
+  @doc "Returns the path of the application's priv directory."
+  def priv_dir(igniter, subpath \\ []) do
+    igniter
+    |> app_name()
+    |> Application.app_dir(["priv"] ++ subpath)
+  end
+
   @doc "Returns the name of the application module."
   def app_module(igniter) do
     zipper =

--- a/test/igniter/project/application_test.exs
+++ b/test/igniter/project/application_test.exs
@@ -379,4 +379,51 @@ defmodule Igniter.Project.ApplicationTest do
       assert is_nil(Igniter.Project.Application.app_module(igniter))
     end
   end
+
+  describe "priv_dir/1" do
+    test "it returns the path of the application's priv directory as string" do
+      igniter = Igniter.new()
+
+      assert String.ends_with?(
+               Igniter.Project.Application.priv_dir(igniter),
+               "_build/test/lib/igniter/priv"
+             )
+    end
+
+    test "it returns the path of the application's priv directory and subpath string" do
+      igniter = Igniter.new()
+
+      assert String.ends_with?(
+               Igniter.Project.Application.priv_dir(igniter, ["test1", ["test2"]]),
+               "_build/test/lib/igniter/priv/test1/test2"
+             )
+    end
+
+    test "it raises if the application name can't be resolved as Application priv_dir" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                [
+                  app: @app
+                ]
+              end
+
+              @app :igniter_test
+            end
+            """
+          }
+        )
+
+      assert_raise RuntimeError, fn -> Igniter.Project.Application.priv_dir(igniter) end
+
+      assert_raise RuntimeError, fn ->
+        Igniter.Project.Application.priv_dir(igniter, ["test1", ["test2"]])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hello Dear igniter team,

Based on the discussion we had in the Ash Discord, I added this `app_name()` combination function to the project to return `priv` directory.

> This priv_dir function simply improves convenience and consistency when working with igniter.

I hope I followed the project format correctly and do not waste your time, as it was a bit different from my usual coding style 🥹.

If there are any issues, please let me know so I can address them.


### Contributor checklist

- [x] Features include unit/acceptance tests
