### PR TITLE
fix: print a consistent number of blank lines around diffs

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -1122,7 +1122,7 @@ defmodule Igniter do
   def diff(sources, opts \\ []) do
     color? = Keyword.get(opts, :color?, true)
 
-    Enum.map_join(sources, "\n", fn source ->
+    Enum.map_join(sources, fn source ->
       source =
         case source do
           {_, source} -> source
@@ -1147,14 +1147,16 @@ defmodule Igniter do
           Enum.map_join(content_lines, "\n", fn {line, line_number_minus_one} ->
             line_number = line_number_minus_one + 1
 
-            "#{String.pad_trailing(to_string(line_number), space_padding)} #{color(IO.ANSI.yellow(), color?)}| #{color(IO.ANSI.green(), color?)}#{line}#{color(IO.ANSI.reset(), color?)}"
+            "#{String.pad_trailing(to_string(line_number), space_padding)} #{color(IO.ANSI.yellow(), color?)}|#{color(IO.ANSI.green(), color?)}#{line}#{color(IO.ANSI.reset(), color?)}"
           end)
 
         if String.trim(diffish_looking_text) != "" do
           """
+
           Create: #{Rewrite.Source.get(source, :path)}
 
           #{diffish_looking_text}
+
           """
         else
           ""
@@ -1164,6 +1166,7 @@ defmodule Igniter do
 
         if String.trim(diff) != "" do
           """
+
           Update: #{Rewrite.Source.get(source, :path)}
 
           #{diff}

--- a/test/igniter_test.exs
+++ b/test/igniter_test.exs
@@ -35,4 +35,53 @@ defmodule IgniterTest do
       """)
     end
   end
+
+  describe "diff formatting" do
+    test "contains uniform blank lines between diifs" do
+      diff =
+        test_project()
+        |> Igniter.update_elixir_file("mix.exs", fn zipper ->
+          {:ok, Igniter.Code.Common.add_code(zipper, ":ok")}
+        end)
+        |> Igniter.update_elixir_file("lib/test.ex", fn zipper ->
+          {:ok, Igniter.Code.Common.add_code(zipper, ":ok")}
+        end)
+        |> Igniter.create_new_file("lib/test/example.ex", ":ok\n")
+        |> Igniter.create_new_file("lib/test/example2.ex", ":ok\n")
+        |> diff()
+
+      assert diff == """
+
+             Update: lib/test.ex
+
+                  ...|
+             18 18   |end
+             19 19   |
+                20 + |:ok
+                21 + |
+
+
+             Create: lib/test/example.ex
+
+             1 |:ok
+             2 |
+
+
+             Create: lib/test/example2.ex
+
+             1 |:ok
+             2 |
+
+
+             Update: mix.exs
+
+                  ...|
+             28 28   |end
+             29 29   |
+                30 + |:ok
+                31 + |
+
+             """
+    end
+  end
 end


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
