### PR TITLE
feat: propagate expand_env? option to Igniter.Code.Common.add_code/3

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -195,7 +195,6 @@ defmodule Igniter.Code.Common do
     end
   end
 
-  @type add_code_opts :: [placement: :after | :before, expand_env?: boolean()]
   @doc """
   Adds the provided code to the zipper.
 
@@ -232,7 +231,8 @@ defmodule Igniter.Code.Common do
   \"\"\"
   ```
   """
-  @spec add_code(Zipper.t(), String.t() | Macro.t(), add_code_opts() | atom()) :: Zipper.t()
+  @spec add_code(Zipper.t(), String.t() | Macro.t(), [opt]) :: Zipper.t()
+        when opt: {:placement, :after | :before} | {:expand_env?, boolean()}
   def add_code(zipper, new_code, opts \\ [])
 
   def add_code(zipper, new_code, placement) when is_atom(placement) do

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -233,7 +233,7 @@ defmodule Igniter.Code.Common do
   ```
   """
   @spec add_code(Zipper.t(), String.t() | Macro.t(), add_code_opts() | atom()) :: Zipper.t()
-  def add_code(zipper, new_code, opts \\ [placement: :after, expand_env?: true])
+  def add_code(zipper, new_code, opts \\ [])
 
   def add_code(zipper, new_code, placement) when is_atom(placement) do
     Logger.warning("""

--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -2,6 +2,8 @@ defmodule Igniter.Code.Common do
   @moduledoc """
   General purpose utilities for working with `Sourceror.Zipper`.
   """
+  require Logger
+
   alias Sourceror.Zipper
 
   @doc """
@@ -233,10 +235,20 @@ defmodule Igniter.Code.Common do
   @spec add_code(Zipper.t(), String.t() | Macro.t(), add_code_opts() | atom()) :: Zipper.t()
   def add_code(zipper, new_code, opts \\ [placement: :after, expand_env?: true])
 
-  def add_code(_zipper, _new_code, placement) when is_atom(placement) do
-    raise ArgumentError, """
-    The `placement` argument is deprecated. Use an opts list of `placement: #{inspect(placement)}` instead.
-    """
+  def add_code(zipper, new_code, placement) when is_atom(placement) do
+    Logger.warning("""
+    Passing an atom as the third argument to `Igniter.Code.Common.add_code/3` is deprecated in favor of an options list.
+
+    Instead of:
+
+        Igniter.Code.Common.add_code(zipper, new_code, #{inspect(placement)})
+
+    You should now write:
+
+        Igniter.Code.Common.add_code(zipper, new_code, placement: #{inspect(placement)})
+    """)
+
+    add_code(zipper, new_code, placement: placement)
   end
 
   def add_code(zipper, new_code, opts) when is_binary(new_code) do

--- a/lib/igniter/libs/phoenix.ex
+++ b/lib/igniter/libs/phoenix.ex
@@ -141,7 +141,7 @@ defmodule Igniter.Libs.Phoenix do
       Igniter.Project.Module.find_and_update_module!(igniter, router, fn zipper ->
         case move_to_scope_location(igniter, zipper) do
           {:ok, zipper, append_or_prepend} ->
-            {:ok, Igniter.Code.Common.add_code(zipper, scope_code, append_or_prepend)}
+            {:ok, Igniter.Code.Common.add_code(zipper, scope_code, placement: append_or_prepend)}
 
           :error ->
             {:warning,
@@ -228,7 +228,8 @@ defmodule Igniter.Libs.Phoenix do
           :error ->
             case move_to_scope_location(igniter, zipper) do
               {:ok, zipper, append_or_prepend} ->
-                {:ok, Igniter.Code.Common.add_code(zipper, scope_code, append_or_prepend)}
+                {:ok,
+                 Igniter.Code.Common.add_code(zipper, scope_code, placement: append_or_prepend)}
 
               :error ->
                 {:warning,
@@ -305,7 +306,8 @@ defmodule Igniter.Libs.Phoenix do
           _ ->
             case move_to_pipeline_location(igniter, zipper) do
               {:ok, zipper, append_or_prepend} ->
-                {:ok, Igniter.Code.Common.add_code(zipper, pipeline_code, append_or_prepend)}
+                {:ok,
+                 Igniter.Code.Common.add_code(zipper, pipeline_code, placement: append_or_prepend)}
 
               :error ->
                 {:warning,
@@ -376,7 +378,8 @@ defmodule Igniter.Libs.Phoenix do
           _ ->
             case move_to_pipeline_location(igniter, zipper) do
               {:ok, zipper, append_or_prepend} ->
-                {:ok, Igniter.Code.Common.add_code(zipper, pipeline_code, append_or_prepend)}
+                {:ok,
+                 Igniter.Code.Common.add_code(zipper, pipeline_code, placement: append_or_prepend)}
 
               :error ->
                 {:warning,

--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -319,7 +319,7 @@ defmodule Igniter.Project.Config do
                       {:ok, Common.add_code(zipper, config)}
 
                     zipper ->
-                      {:ok, Common.add_code(zipper, config, :before)}
+                      {:ok, Common.add_code(zipper, config, placement: :before)}
                   end
 
                 :error ->
@@ -330,7 +330,7 @@ defmodule Igniter.Project.Config do
                       {:ok, Common.add_code(zipper, config)}
 
                     zipper ->
-                      {:ok, Common.add_code(zipper, config, :before)}
+                      {:ok, Common.add_code(zipper, config, placement: :before)}
                   end
               end
           end

--- a/lib/igniter/refactors/rename.ex
+++ b/lib/igniter/refactors/rename.ex
@@ -248,7 +248,7 @@ defmodule Igniter.Refactors.Rename do
                      Igniter.Code.Common.add_code(
                        zipper,
                        deprecation,
-                       :before
+                       placement: :before
                      )}
                   end
                 else


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

We ran into an issue when using igniter with [styler](https://hexdocs.pm/styler/0.8.0/readme.html), where the formatting would move the `@behaviour` tag above the aliases, and then would be incorrectly aliased. I found that using the `expand_env?` argument fixes this, and propagated the option up to `add_code/3`. 

I made an opinionated change here to convert it to an `opts` list, which creates a breaking change for its usage, happy to change if this is too breaking!

Also happy to close this in order to discuss if this doesn't fit the project goals.