### PR TITLE
Fix parse_argv callback should be overridable

### DIFF
--- a/lib/mix/task.ex
+++ b/lib/mix/task.ex
@@ -123,7 +123,7 @@ defmodule Igniter.Mix.Task do
         %Args{positional: positional, options: options, argv: argv, argv_flags: argv_flags}
       end
 
-      defoverridable supports_umbrella?: 0, info: 2, installer?: 0
+      defoverridable supports_umbrella?: 0, info: 2, installer?: 0, parse_argv: 1
     end
   end
 


### PR DESCRIPTION
Otherwise an overridden `parse_argv/1` has no effect, as pointed out by dialyzer.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Not sure how to test this TBH.