### PR TITLE
fix: Igniter.mkdir not expanding paths correctly

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -1024,7 +1024,7 @@ defmodule Igniter do
                   end
 
                   igniter.mkdirs
-                  |> Enum.map(&Path.expand(&1, ""))
+                  |> Enum.map(&Path.expand(&1, "."))
                   |> Enum.uniq()
                   |> Enum.each(fn path ->
                     File.mkdir_p!(path)


### PR DESCRIPTION
Existing code would expand to paths outside of project.

Don't quite know how this bug made it in - apologies.

Tried to set up testing, but think we should have Rewrite support for mkdir upstream, before good tests can be made.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
