### PR TITLE
improvement: print version diff when upgrading packages

### DIFF
--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -258,10 +258,9 @@ defmodule Mix.Tasks.Igniter.Upgrade do
             end)
             |> String.trim_trailing("\n")
 
-          Igniter.add_notice(
-            igniter,
-            "The packages `#{missing}` did not have upgrade tasks.\nUpgraded packages:\n#{upgrades}"
-          )
+          igniter
+          |> Igniter.add_notice("The packages `#{missing}` did not have upgrade tasks.")
+          |> Igniter.add_notice("Upgraded packages:\n#{upgrades}")
       end
     rescue
       e ->

--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -245,6 +245,11 @@ defmodule Mix.Tasks.Igniter.Upgrade do
           igniter
 
         {igniter, missing} ->
+          missing =
+            missing
+            |> Enum.sort()
+            |> Enum.join(", ")
+
           upgrades =
             dep_changes
             |> Enum.sort()
@@ -255,7 +260,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
 
           Igniter.add_notice(
             igniter,
-            "The packages `#{Enum.join(missing, ", ")}` did not have upgrade tasks.\nUpgraded packages:\n#{upgrades}"
+            "The packages `#{missing}` did not have upgrade tasks.\nUpgraded packages:\n#{upgrades}"
           )
       end
     rescue

--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -245,9 +245,17 @@ defmodule Mix.Tasks.Igniter.Upgrade do
           igniter
 
         {igniter, missing} ->
+          upgrades =
+            dep_changes
+            |> Enum.sort()
+            |> Enum.map_join("\n", fn {app, from, to} ->
+              "#{app} #{from} => #{to}"
+            end)
+            |> String.trim_trailing("\n")
+
           Igniter.add_notice(
             igniter,
-            "The packages `#{Enum.join(missing, ", ")}` did not have upgrade tasks."
+            "The packages `#{Enum.join(missing, ", ")}` did not have upgrade tasks.\nUpgraded packages:\n#{upgrades}"
           )
       end
     rescue


### PR DESCRIPTION
## Implements

- Prints out the version diff when upgrading a package; similar behaviour to what `mix deps.upgrade` does

Please let me know if a test is wanted for this 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
