### PR TITLE
Default `yes?` to Y

### DIFF
--- a/lib/igniter/util/io.ex
+++ b/lib/igniter/util/io.ex
@@ -3,7 +3,11 @@ defmodule Igniter.Util.IO do
 
   @doc "Prompts the user for yes or no, repeating the prompt until a satisfactory answer is given"
   def yes?(prompt) do
-    case String.trim(Mix.shell().prompt(prompt <> " [y/n]")) do
+    case String.trim(Mix.shell().prompt(prompt <> " [Y/n]")) do
+      # default answer Y
+      "" ->
+        true
+
       yes when yes in ["y", "Y", "yes", "YES"] ->
         true
 


### PR DESCRIPTION
Close #193

```
❯ mix igniter.install phoenix_test
==> igniter
Generated igniter app
compile ✔
==> my_app

Update: mix.exs

     ...|
33 33   |  defp deps do
34 34   |    [
   35 + |      {:phoenix_test, "~> 0.5"},
35 36   |      {:igniter, "~> 0.5", path: "/Users/leandro/code/github/leandrocp/igniter"},
36 37   |      {:phoenix, "~> 1.7.18"},
     ...|


These dependencies should be installed before continuing. Modify mix.exs and install? [Y/n]

Update: mix.exs

     ...|
42 42   |      {:phoenix_live_reload, "~> 1.2", only: :dev},
43 43   |      {:phoenix_live_view, "~> 1.0.0"},
44    - |      {:floki, ">= 0.30.0", only: :test},
   44 + |      {:floki, ">= 0.30.0"},
45 45   |      {:phoenix_live_dashboard, "~> 0.8.3"},
46 46   |      {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
     ...|


Conflict in `only` option for dependency :floki.
Between your application and the :phoenix_test dependency.

We must update the `only` option as shown to continue.
 [Y/n]
recompiling conflicts ✔
compiling phoenix_test ✔

Successfully installed:

* phoenix_test
```