### PR TITLE
Add `:after` opt to `Config` functions

### DIFF
--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -5,15 +5,18 @@ defmodule Igniter.Project.Config do
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 
+  @type updater :: (Sourceror.Zipper.t() -> {:ok, Sourceror.Zipper.t()}) | :error | nil
+  @type after_predicate :: (Sourceror.Zipper.t() -> boolean())
+
   @doc """
   Sets a config value in the given configuration file, if it is not already set.
 
   See `configure/6` for more.
 
-  ## Opts
+  ## Options
 
   * `failure_message` - A message to display to the user if the configuration change is unsuccessful.
-  * `after` - Moves to the next node that matches the predicate.
+  * `after` - `t:after_predicate/0`. Moves to the last node that matches the predicate.
   """
   @spec configure_new(Igniter.t(), Path.t(), atom(), list(atom), term(), opts :: Keyword.t()) ::
           Igniter.t()
@@ -140,11 +143,11 @@ defmodule Igniter.Project.Config do
   )
   ```
 
-  ## Opts
+  ## Options
 
   * `failure_message` - A message to display to the user if the configuration change is unsuccessful.
-  * `updater` - A function that takes a zipper at a currently configured value and returns a new zipper with the value updated.
-  * `after` - Moves to the next node that matches the predicate. Useful to guarantee a `config` is placed after a specific node.
+  * `updater` - `t:updater/0`. A function that takes a zipper at a currently configured value and returns a new zipper with the value updated.
+  * `after` - `t:after_predicate/0`. Moves to the last node that matches the predicate. Useful to guarantee a `config` is placed after a specific node.
   """
   @spec configure(
           Igniter.t(),
@@ -273,6 +276,11 @@ defmodule Igniter.Project.Config do
 
   If you want to set configuration, use `configure/6` or `configure_new/5` instead. This is a lower-level
   tool for modifying configuration files when you need to adjust some specific part of them.
+
+  ## Options
+
+  * `updater` - `t:updater/0`. A function that takes a zipper at a currently configured value and returns a new zipper with the value updated.
+  * `after` - `t:after_predicate/0`. Moves to the last node that matches the predicate.
   """
   @spec modify_configuration_code(
           Zipper.t(),
@@ -359,7 +367,7 @@ defmodule Igniter.Project.Config do
   end
 
   defp move_to_after(zipper, pred) when is_function(pred, 1) do
-    case Igniter.Code.Common.move_to(zipper, pred) do
+    case Common.move_to_last(zipper, pred) do
       {:ok, zipper} -> zipper
       :error -> zipper
     end

--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -281,7 +281,15 @@ defmodule Igniter.Project.Config do
           term(),
           opts :: Keyword.t()
         ) :: Zipper.t()
-  def modify_configuration_code(zipper, config_path, app_name, value, opts \\ []) do
+  def modify_configuration_code(zipper, config_path, app_name, value, opts \\ [])
+
+  def modify_configuration_code(zipper, config_path, app_name, value, updater)
+      when is_function(updater) do
+    IO.warn("updater argument is deprecated, please use opts updater: fun instead")
+    modify_configuration_code(zipper, config_path, app_name, value, updater: updater)
+  end
+
+  def modify_configuration_code(zipper, config_path, app_name, value, opts) do
     updater = opts[:updater] || fn zipper -> {:ok, Common.replace_code(zipper, value)} end
 
     Igniter.Code.Common.within(zipper, fn zipper ->

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -5,6 +5,33 @@ defmodule Igniter.Code.CommonTest do
   require Igniter.Code.Function
   import ExUnit.CaptureLog
 
+  describe "move_to_last/2" do
+    test "no matching nodes returns :error" do
+      assert :error =
+               """
+               foo = 1
+               """
+               |> Sourceror.parse_string!()
+               |> Sourceror.Zipper.zip()
+               |> Igniter.Code.Common.move_to_last(&match?({:=, _, [{:bar, _, _}, _]}, &1.node))
+    end
+
+    test "move to the last matching node" do
+      assert {:ok, zipper} =
+               """
+               foo = 1
+               bar = 1
+               foo = 2
+               bar = 2
+               """
+               |> Sourceror.parse_string!()
+               |> Sourceror.Zipper.zip()
+               |> Igniter.Code.Common.move_to_last(&match?({:=, _, [{:foo, _, _}, _]}, &1.node))
+
+      assert Igniter.Util.Debug.code_at_node(zipper) == "foo = 2"
+    end
+  end
+
   describe "topmost/1" do
     test "escapes subtrees using `within`" do
       """

--- a/test/igniter/project/config_test.exs
+++ b/test/igniter/project/config_test.exs
@@ -413,12 +413,13 @@ defmodule Igniter.Project.ConfigTest do
                |> apply_igniter()
     end
 
-    test "places code after matching node" do
+    test "places code after last matching node" do
       test_project()
       |> Igniter.create_new_file("config/fake.exs", """
       import Config
 
-      foo = "bar"
+      foo = 1
+      foo = 2
 
       if System.get_env("PHX_SERVER") do
         config :fake, FakeWeb.Endpoint, server: true
@@ -433,12 +434,11 @@ defmodule Igniter.Project.ConfigTest do
         after: &match?({:=, _, [{:foo, _, _}, _]}, &1.node)
       )
       |> assert_has_patch("config/fake.exs", """
-      3  3   |foo = "bar"
-      4  4   |
-         5 + |config :fake, foo: foo
-         6 + |
-      5  7   |if System.get_env("PHX_SERVER") do
-      6  8   |  config :fake, FakeWeb.Endpoint, server: true
+      4  4   |foo = 2
+      5  5   |
+         6 + |config :fake, foo: foo
+         7 + |
+      6  8   |if System.get_env("PHX_SERVER") do
       """)
     end
 

--- a/test/igniter/project/config_test.exs
+++ b/test/igniter/project/config_test.exs
@@ -568,9 +568,11 @@ defmodule Igniter.Project.ConfigTest do
 
       config =
         zipper
-        |> Igniter.Project.Config.modify_configuration_code([:foo], :fake, true, updater: fn zipper ->
-          Igniter.Code.Keyword.put_in_keyword(zipper, [:bar], true)
-        end)
+        |> Igniter.Project.Config.modify_configuration_code([:foo], :fake, true,
+          updater: fn zipper ->
+            Igniter.Code.Keyword.put_in_keyword(zipper, [:bar], true)
+          end
+        )
         |> Igniter.Util.Debug.code_at_node()
 
       assert String.contains?(config, "config :fake, foo: [bar: true]")


### PR DESCRIPTION
Expose an opt to move to a matching node.

* Add `:after` opt to `Config` functions
    - `configure_new/6`
    - `configure/6`
    - `modify_configuration_code/5`
    
* Replace `updater` arg with `opts` in `modify_configuration_code/5`
This introduces a breaking change but it seems more appropriate than adding a new arg. I can revert it tho.

---

Notes:
1. I can push more docs and examples, I just wanted to confirm this looks good first.
2. `move_to/2` is recursive already