### PR TITLE
Add support for passing options to an install

### DIFF
--- a/lib/igniter/util/install.ex
+++ b/lib/igniter/util/install.ex
@@ -26,12 +26,16 @@ defmodule Igniter.Util.Install do
   def install([head | _] = deps, argv, igniter, opts) when is_binary(head) do
     deps =
       Enum.map(deps, fn dep ->
-        case Igniter.Project.Deps.determine_dep_type_and_version(dep) do
-          {install, requirement} ->
-            {install, requirement}
-
-          :error ->
+        case {Igniter.Project.Deps.determine_dep_type_and_version(dep),
+              Igniter.Project.Deps.determine_dep_opts(dep)} do
+          {:error, _} ->
             raise "Could not determine source for requested package #{dep}"
+
+          {_, :error} ->
+            raise "Could not parse options for request package #{dep}"
+
+          {{install, requirement}, options} ->
+            {install, requirement, options}
         end
       end)
 
@@ -108,7 +112,7 @@ defmodule Igniter.Util.Install do
 
       If you don't yet have a `.igniter.exs`, run `mix igniter.setup`.
 
-      For more information, see: 
+      For more information, see:
 
       https://hexdocs.pm/igniter/Igniter.Project.IgniterConfig.html
       """)
@@ -306,7 +310,7 @@ defmodule Igniter.Util.Install do
 
               If you don't yet have a `.igniter.exs`, run `mix igniter.setup`.
 
-              For more information, see: 
+              For more information, see:
 
               https://hexdocs.pm/igniter/Igniter.Project.IgniterConfig.html
               """)
@@ -376,7 +380,7 @@ defmodule Igniter.Util.Install do
 
           igniter ->
             message = """
-            Conflict in `only` option for dependency #{inspect(dep)}. 
+            Conflict in `only` option for dependency #{inspect(dep)}.
             Between #{source1} and #{source2}.
 
             We must update the `only` option as shown to continue.


### PR DESCRIPTION
Install can now be done with:

```
mix igniter.install nerves#runtime=false`
```

Producing:

```
{:nerves, "~> x.y.z", [runtime: false]}
```

To avoid a bunch of fun problems with spaces, commas and such the format is a query string. Spaces and other nasty characters will need to be encoded. The encoding exists in the standard library. It will allow creating Igniter install tasks for Nerves systems and similar that have some fairly particular options.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
