### PR TITLE
fix: find app_name when kw list is defined at the end

### DIFF
--- a/lib/igniter/project/application.ex
+++ b/lib/igniter/project/application.ex
@@ -26,8 +26,10 @@ defmodule Igniter.Project.Application do
       |> Sourceror.Zipper.zip()
 
     with {:ok, zipper} <- Igniter.Code.Function.move_to_def(zipper, :project, 0),
-         zipper <- Igniter.Code.Common.rightmost(zipper),
-         true <- Igniter.Code.List.list?(zipper),
+         {:ok, zipper} <-
+           Igniter.Code.Common.move_to(zipper, &match?({:__block__, _, [:app]}, &1.node)),
+         zipper = Zipper.up(zipper),
+         zipper = Zipper.up(zipper),
          {:ok, zipper} <- Igniter.Code.Keyword.get_key(zipper, :app),
          {:ok, app_name} when is_atom(app_name) <- expand_key_value(zipper) do
       app_name

--- a/test/igniter/project/application_test.exs
+++ b/test/igniter/project/application_test.exs
@@ -231,6 +231,56 @@ defmodule Igniter.Project.ApplicationTest do
       assert Igniter.Project.Application.app_name(igniter) == :igniter_test
     end
 
+    test "it returns the application name when keyword list is defined at the end" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                releases = [
+                  test: []
+                ]
+
+                [
+                  app: :igniter_test,
+                  releases: releases
+                ]
+              end
+            end
+            """
+          }
+        )
+
+      assert Igniter.Project.Application.app_name(igniter) == :igniter_test
+    end
+
+    test "it returns the application name when keyword list is assigned to a variable" do
+      igniter =
+        test_project(
+          files: %{
+            "mix.exs" => """
+            defmodule IgniterTest.MixProject do
+              use Mix.Project
+
+              def project do
+                project = [
+                  app: :igniter_test,
+                  releases: releases
+                ]
+
+                project
+              end
+            end
+            """
+          }
+        )
+
+      assert Igniter.Project.Application.app_name(igniter) == :igniter_test
+    end
+
     test "it raises if the application name can't be resolved" do
       igniter =
         test_project(


### PR DESCRIPTION
Close #235

So the logic here is to find where `:app` is defined inside `project/0`, which does cover the case described at #235 and also cases where the kw list is assigned to a variable. Although it wouldn't cover some edge cases like for eg:

```elixir
def project do
  default = [
    app: :igniter_test
  ]

  Keyword.merge(default, other())
end
```

But I'm not sure if that should even be supported. Let me know if there's a better approach.