### PR TITLE
Fix broken Map.get in Module.find_module

### DIFF
--- a/lib/igniter/project/module.ex
+++ b/lib/igniter/project/module.ex
@@ -236,8 +236,7 @@ defmodule Igniter.Project.Module do
 
     matching_modules =
       igniter
-      |> Map.get([:rewrite, :sources], %{})
-      |> Map.values()
+      |> Map.get(:rewrite)
       |> Enum.filter(&match?(%Rewrite.Source{filetype: %Rewrite.Source.Ex{}}, &1))
       |> Task.async_stream(
         fn source ->


### PR DESCRIPTION
## Changes

This commit changes the call in line 312 from `Map.get(:rewrites)` to `Map.get([:rewrite, :sources])`

## Motivation

`Igniter.Libs.Ecto.gen_migration` crashed randomly with a `Protocol Enum not implemented for type %Rewrite{}`. This seems to be caused by the `find_module` method trying to iterate over a `Rewrite` object instead of its iterable field `:sources`, which is further indicated by a pattern match against `%Source{}` up next in the pipeline.


---
### Code

> (unable to provide a better example ATM sadly)

```elixir
...

content = "example module code"
Igniter.Libs.Ecto.gen_migration(igniter, MyApp.Repo, MyApp.MyModule, body: content, on_exists: :skip)

...
```

### Output

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for type Rewrite (a struct). This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Stream

Got value:

    #Rewrite<4 source(s)>

    (elixir 1.18.0) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.18.0) lib/enum.ex:166: Enumerable.reduce/3
    (elixir 1.18.0) lib/enum.ex:4511: Enum.reduce/3
    (igniter 0.5.25) lib/igniter.ex:1399: Igniter.format/3
    (elixir 1.18.0) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (imazon 0.1.0) lib/mix/tasks/notlib/add.ex:28: Mix.Tasks.Notlib.Add.igniter/1
    (imazon 0.1.0) lib/mix/tasks/notlib/add.ex:2: Mix.Tasks.Notlib.Add.run/1
    (mix 1.18.0) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
```