### PR TITLE
Switch to doctest for Igniter.Code.Common.add_code/3

### DIFF
--- a/lib/igniter/code/common.ex
+++ b/lib/igniter/code/common.ex
@@ -257,14 +257,14 @@ defmodule Igniter.Code.Common do
 
   ## Example:
 
-      iex> existing_zipper = Igniter.Code.Common.parse_to_zipper!("""
+      iex> existing_zipper = Igniter.Code.Common.parse_to_zipper!(\"""
       ...> IO.inspect("abc")
-      ...> """)
+      ...> \""")
       ...>
       ...> existing_zipper
-      ...> |> Igniter.Code.Common.add_code("""
+      ...> |> Igniter.Code.Common.add_code(\"""
       ...> IO.inspect("Goodbye, world!")
-      ...> """, after: true)
+      ...> \""", after: true)
       ...> |> Sourceror.Zipper.root()
       ...> |> Sourceror.to_string()
       "IO.inspect(\\"abc\\")

--- a/test/igniter/code/common_test.exs
+++ b/test/igniter/code/common_test.exs
@@ -4,6 +4,7 @@ defmodule Igniter.Code.CommonTest do
   use ExUnit.Case
   require Igniter.Code.Function
   import ExUnit.CaptureLog
+  doctest Igniter.Code.Common
 
   describe "move_to_last/2" do
     test "no matching nodes returns :error" do


### PR DESCRIPTION
Fixes a typo in the existing docs and switches to doctests to ensure that the docs do not get out of date.

But I am not quite 100% convinced that this is necessarily more readable, it feels a bit awkward to me. I wish I could write a better assertion as the last line of the doctest, we could use a heredoc but then we'd have to annoyingly deal with the trailing newline.

Here's the new and old docs:
| Old       | New     |
| ---------- | ------ |
| ![Screenshot 2025-03-08 14-17-05@2x](https://github.com/user-attachments/assets/5c6ac5f8-dae1-4a29-9263-bc471291f8b3) | ![Screenshot 2025-03-08 14-17-27@2x](https://github.com/user-attachments/assets/0d6ae083-ec4d-47e5-adcd-68807cabb46c) |

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
