### PR TITLE
Add `:placement` option to `Phoenix.add_scope/4` and `Phoenix.append_to_scope/4`

### DIFF
--- a/lib/igniter/libs/phoenix.ex
+++ b/lib/igniter/libs/phoenix.ex
@@ -135,9 +135,7 @@ defmodule Igniter.Libs.Phoenix do
 
   - `:router` - The router module to append to. Will be looked up if not provided.
   - `:arg2` - The second argument to the scope macro. Must be a value (typically a module).
-  - `:placement` - `:before` | `:after`. Determines where the `contents` will be placed. Note that it first tries
-    to find a matching scope and place the contents into that scope, otherwise `:placement` is used to determine
-    where to place the contents:
+  - `:placement` - `:before` | `:after`. Determines where the `contents` will be placed:
     - `:before` - place before the first scope in the module if one is found, otherwise tries to place
        after the last pipeline or after the `use MyAppWeb, :router` call.
     - `:after` - place at the end (bottom) of the module, after all scopes and pipelines.

--- a/test/igniter/libs/phoenix_test.exs
+++ b/test/igniter/libs/phoenix_test.exs
@@ -66,4 +66,184 @@ defmodule Igniter.Libs.PhoenixTest do
   test "web_module_name/1" do
     assert Igniter.Libs.Phoenix.web_module_name(test_project(), "Suffix") == TestWeb.Suffix
   end
+
+  describe "add_scope/4" do
+    setup do
+      router = """
+      defmodule TestWeb.Router do
+        use TestWeb, :router
+
+        pipeline :browser do
+          plug :accepts, ["html"]
+        end
+
+        scope "/", TestWeb do
+          pipe_through :browser
+          get "/", PageController, :home
+        end
+
+        if Application.compile_env(:test, :dev_routes) do
+          scope "/dev" do
+            pipe_through :browser
+            live_dashboard "/dashboard", metrics: TestWeb.Telemetry
+          end
+        end
+      end
+      """
+
+      igniter =
+        assert test_project()
+               |> Igniter.create_or_update_elixir_file(
+                 "lib/test_web/router.ex",
+                 router,
+                 &{:ok, Igniter.Code.Common.replace_code(&1, router)}
+               )
+               |> apply_igniter!()
+
+      {igniter, router} = Igniter.Libs.Phoenix.select_router(igniter)
+
+      [igniter: igniter, router: router]
+    end
+
+    test "before existing scopes", %{igniter: igniter, router: router} do
+      igniter
+      |> Igniter.Libs.Phoenix.add_scope(
+        "/test",
+        """
+        get "/", TestController, :test
+        """,
+        router: router,
+        placement: :before
+      )
+      |> assert_has_patch("lib/test_web/router.ex", """
+         8 + |  scope "/test" do
+         9 + |    get("/", TestController, :test)
+        10 + |  end
+        11 + |
+      8 12   |  scope "/", TestWeb do
+      """)
+    end
+
+    test "after existing scopes", %{igniter: igniter, router: router} do
+      igniter
+      |> Igniter.Libs.Phoenix.append_to_scope(
+        "/test",
+        """
+        get "/", TestController, :test
+        """,
+        router: router,
+        placement: :after
+      )
+      |> assert_has_patch("lib/test_web/router.ex", """
+      18 18   |  end
+         19 + |
+         20 + |  scope "/test" do
+         21 + |    get("/", TestController, :test)
+         22 + |  end
+      19 23   |end
+      """)
+    end
+  end
+
+
+  describe "append_to_scope/4" do
+    setup do
+      router = """
+      defmodule TestWeb.Router do
+        use TestWeb, :router
+
+        pipeline :browser do
+          plug :accepts, ["html"]
+        end
+
+        scope "/", TestWeb do
+          pipe_through :browser
+          get "/", PageController, :home
+        end
+
+        if Application.compile_env(:test, :dev_routes) do
+          scope "/dev" do
+            pipe_through :browser
+            live_dashboard "/dashboard", metrics: TestWeb.Telemetry
+          end
+        end
+      end
+      """
+
+      igniter =
+        assert test_project()
+               |> Igniter.create_or_update_elixir_file(
+                 "lib/test_web/router.ex",
+                 router,
+                 &{:ok, Igniter.Code.Common.replace_code(&1, router)}
+               )
+               |> apply_igniter!()
+
+      {igniter, router} = Igniter.Libs.Phoenix.select_router(igniter)
+
+      [igniter: igniter, router: router]
+    end
+
+    test "update matching scope", %{igniter: igniter, router: router} do
+      igniter
+      |> Igniter.Libs.Phoenix.append_to_scope(
+        "/",
+        """
+        get "/", TestController, :test
+        """,
+        router: router,
+        arg2: Igniter.Libs.Phoenix.web_module(igniter),
+        with_pipelines: [:browser],
+        placement: :before
+      )
+      |> assert_has_patch("lib/test_web/router.ex", """
+       9  9   |    pipe_through(:browser)
+      10 10   |    get("/", PageController, :home)
+         11 + |    get("/", TestController, :test)
+      """)
+    end
+
+    test "before existing scopes when no one matches", %{igniter: igniter, router: router} do
+      igniter
+      |> Igniter.Libs.Phoenix.append_to_scope(
+        "/test",
+        """
+        get "/", TestController, :test
+        """,
+        router: router,
+        with_pipelines: [:browser],
+        placement: :before
+      )
+      |> assert_has_patch("lib/test_web/router.ex", """
+         8 + |  scope "/test" do
+         9 + |    pipe_through([:browser])
+        10 + |    get("/", TestController, :test)
+        11 + |  end
+        12 + |
+      8 13   |  scope "/", TestWeb do
+      """)
+    end
+
+    test "after existing scopes when no one matches", %{igniter: igniter, router: router} do
+      igniter
+      |> Igniter.Libs.Phoenix.append_to_scope(
+        "/test",
+        """
+        get "/", TestController, :test
+        """,
+        router: router,
+        with_pipelines: [:browser],
+        placement: :after
+      )
+      |> assert_has_patch("lib/test_web/router.ex", """
+      18 18   |  end
+         19 + |
+         20 + |  scope "/test" do
+         21 + |    pipe_through([:browser])
+         22 + |    get("/", TestController, :test)
+         23 + |  end
+      19 24   |end
+      """)
+    end
+  end
 end

--- a/test/igniter/libs/phoenix_test.exs
+++ b/test/igniter/libs/phoenix_test.exs
@@ -145,7 +145,6 @@ defmodule Igniter.Libs.PhoenixTest do
     end
   end
 
-
   describe "append_to_scope/4" do
     setup do
       router = """


### PR DESCRIPTION
Hey @zachdaniel here's a PoC to allow customization of routes placement. To fix that conflict between `beacon_site "/"` and Ash Admin in the ash-hq.org generator and also to fix https://github.com/BeaconCMS/beacon/issues/744

I'm not sure about the names in the `:placement` option (Idk if there's a pattern) but `:before_first_scope` is the current behavior that tries to place the route before the first scope, or after the last pipeline, or after use Router. The new option `: bottom_of_module` (not a great name) just place the code at the end of the file.

Here's how the patched file looks like:

```elixir
defmodule TestWeb.Router do
  use TestWeb, :router

  use Beacon.Router

  pipeline :beacon do
    plug Beacon.Plug
  end

  pipeline :browser do
    plug(:accepts, ["html"])
    plug(:fetch_session)
    plug(:fetch_live_flash)
    plug(:put_root_layout, html: {TestWeb.Layouts, :root})
    plug(:protect_from_forgery)
    plug(:put_secure_browser_headers)
  end

  pipeline :api do
    plug(:accepts, ["json"])
  end

  scope "/", TestWeb do
    pipe_through(:browser)

    get("/", PageController, :home)
  end

  # Other scopes may use custom stacks.
  # scope "/api", TestWeb do
  #   pipe_through :api
  # end

  # Enable LiveDashboard and Swoosh mailbox preview in development
  if Application.compile_env(:test, :dev_routes) do
    # If you want to use the LiveDashboard in production, you should put
    # it behind authentication and allow only admins to access it.
    # If your application does not have an admins-only section yet,
    # you can use Plug.BasicAuth to set up some basic authentication
    # as long as you are also using SSL (which you should anyway).
    import Phoenix.LiveDashboard.Router

    scope "/dev" do
      pipe_through(:browser)

      live_dashboard("/dashboard", metrics: TestWeb.Telemetry)
      forward("/mailbox", Plug.Swoosh.MailboxPreview)
    end
  end

  scope "/", alias: TestWeb do
    pipe_through [:browser, :beacon]
    beacon_site "/", site: :my_site
  end
end


```