### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,7 +348,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes:
 
-* propertly iterate over tasks list
+* properly iterate over tasks list
 
 ## [v0.5.6](https://github.com/ash-project/igniter/compare/v0.5.5...v0.5.6) (2025-01-05)
 
@@ -1425,7 +1425,7 @@ See [Conventional Commits](Https://conventionalcommits.org) for commit guideline
 
 - use warnings instead of errors for better UX
 
-- move proejct related things to `Project` namespace
+- move project related things to `Project` namespace
 
 ## [v0.1.8](https://github.com/ash-project/igniter/compare/v0.1.7...v0.1.8) (2024-06-19)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,12 +16,12 @@ to make it a bit clearer.
 
 You *typically* won't need to do this, but if CI fails for some reason, or you are in a hurry,
 you can run `mix hex.publish` to publish the hex package. CI will fail if you publish it
-before CI gets to tha step. This is fine.
+before CI gets to that step. This is fine.
 
 ## publishing the installer `igniter_new`
 
-The process for this is less rigorous. You manually bump the verison in `installer/mix.exs`,
-cd into `/installer` and then run `mix hex.publish`, and thats it :)
+The process for this is less rigorous. You manually bump the version in `installer/mix.exs`,
+cd into `/installer` and then run `mix hex.publish`, and that's it :)
 If you've published a new version of `igniter` that should affect what version the
 installer uses, edit `@igniter_version` module attribute in `installer/lib/mix/tasks/igniter.new.ex`
 to match the new requirement.

--- a/documentation/upgrades.md
+++ b/documentation/upgrades.md
@@ -23,7 +23,7 @@ While you are free to implement this logic however you like, we suggest using
 The new version of the package must be "compile compatible" with your existing code. For this reason,
 we encourage library authors to make even _major_ versions compile compatible with previous versions, but
 this is not always possible. For those cases, we encourage library authors to provide a version _prior_
-to their breaking changes that includs an upgrader to code that is compatible with the new version. This way,
+to their breaking changes that includes an upgrader to code that is compatible with the new version. This way,
 you can at least instruct users to `mix igniter.upgrade package@that.version` before upgrading to the latest
 version.
 

--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -351,7 +351,7 @@ defmodule Igniter do
     end
   end
 
-  @doc "Adds a task to the tasks list. Tasks will be run after all changes have been commited"
+  @doc "Adds a task to the tasks list. Tasks will be run after all changes have been committed"
   def add_task(igniter, task, argv \\ []) when is_binary(task) do
     %{igniter | tasks: igniter.tasks ++ [{task, argv}]}
   end

--- a/lib/mix/task/info.ex
+++ b/lib/mix/task/info.ex
@@ -53,7 +53,7 @@ defmodule Igniter.Mix.Task.Info do
   ## Options
 
   The schema is an option parser schema, and `OptionParser` is used to parse the options, with
-  a few noteable differences.
+  a few notable differences.
 
   - The defaults from the `defaults` option in your task info are applied.
   - The `:keep` type is automatically aggregated into a list.

--- a/lib/mix/tasks/igniter.move_files.ex
+++ b/lib/mix/tasks/igniter.move_files.ex
@@ -1,5 +1,5 @@
 defmodule Mix.Tasks.Igniter.MoveFiles do
-  @moduledoc "Moves any relavant files to their 'correct' location."
+  @moduledoc "Moves any relevant files to their 'correct' location."
   @shortdoc @moduledoc
   use Igniter.Mix.Task
 

--- a/lib/mix/tasks/igniter.phx.install.ex
+++ b/lib/mix/tasks/igniter.phx.install.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Igniter.Phx.Install do
 
     if !Code.ensure_loaded?(Phx.New.Generator) do
       Mix.raise("""
-      Phoenix installer is not available. Please install it before proceding:
+      Phoenix installer is not available. Please install it before proceeding:
 
         mix archive.install hex phx_new
 

--- a/lib/mix/tasks/igniter.refactor.unless_to_if_not.ex
+++ b/lib/mix/tasks/igniter.refactor.unless_to_if_not.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Igniter.Refactor.UnlessToIfNot do
 
   @example "mix igniter.refactor.unless_to_if_not"
 
-  @shortdoc "Rewrites occurences of `unless x` to `if !x` across the project."
+  @shortdoc "Rewrites occurrences of `unless x` to `if !x` across the project."
   @moduledoc """
   #{@shortdoc}
 

--- a/test/igniter/mix/task_test.exs
+++ b/test/igniter/mix/task_test.exs
@@ -284,7 +284,7 @@ defmodule Igniter.Mix.TaskTest do
   end
 
   describe "parse_argv/1" do
-    defmodule ExampleTaskWithOverridenParseArgv do
+    defmodule ExampleTaskWithOverriddenParseArgv do
       use Igniter.Mix.Task
 
       def parse_argv(_argv) do
@@ -299,8 +299,8 @@ defmodule Igniter.Mix.TaskTest do
       end
     end
 
-    test "can be overriden" do
-      ExampleTaskWithOverridenParseArgv.run([])
+    test "can be overridden" do
+      ExampleTaskWithOverriddenParseArgv.run([])
 
       assert_received {:args, %Igniter.Mix.Task.Args{argv: :overridden}}
     end

--- a/test/igniter/project/application_test.exs
+++ b/test/igniter/project/application_test.exs
@@ -28,7 +28,7 @@ defmodule Igniter.Project.ApplicationTest do
       """)
     end
 
-    test "doesnt add a module if its already supervised" do
+    test "doesn't add a module if its already supervised" do
       test_project()
       |> Igniter.Project.Application.add_new_child(Foo)
       |> apply_igniter!()
@@ -36,7 +36,7 @@ defmodule Igniter.Project.ApplicationTest do
       |> assert_unchanged()
     end
 
-    test "doesnt add a module if its already supervised as a tuple" do
+    test "doesn't add a module if its already supervised as a tuple" do
       test_project()
       |> Igniter.Project.Application.add_new_child({Foo, a: 1})
       |> apply_igniter!()
@@ -44,7 +44,7 @@ defmodule Igniter.Project.ApplicationTest do
       |> assert_unchanged()
     end
 
-    test "doesnt add a module if its already supervised as an atom and we're adding a tuple" do
+    test "doesn't add a module if its already supervised as an atom and we're adding a tuple" do
       test_project()
       |> Igniter.Project.Application.add_new_child(Foo)
       |> apply_igniter!()

--- a/test/igniter/project/igniter_config_test.exs
+++ b/test/igniter/project/igniter_config_test.exs
@@ -23,7 +23,7 @@ defmodule Igniter.Project.IgniterConfigTest do
       """)
     end
 
-    test "doesnt add a duplicate pattern to the list" do
+    test "doesn't add a duplicate pattern to the list" do
       test_project()
       |> Igniter.Project.IgniterConfig.dont_move_file_pattern(~r"lib/mix")
       |> assert_unchanged(".igniter.exs")

--- a/test/igniter/project/test_test.exs
+++ b/test/igniter/project/test_test.exs
@@ -44,7 +44,7 @@ defmodule Igniter.Project.TestTest do
              )
     end
 
-    test "it doesnt change anything if the setting is already configured" do
+    test "it doesn't change anything if the setting is already configured" do
       assert %{rewrite: rewrite} =
                Igniter.new()
                |> Igniter.include_existing_file("mix.exs")


### PR DESCRIPTION
Found via `codespell -S deps -L filetest,reenable` and `typos --hidden --format brief`

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
