### PR TITLE
fix: igniter.upgrade crash on dependency when only option is an atom

### DIFF
--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -482,6 +482,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
           _ ->
             nil
         end
+        |> List.wrap()
 
       allowed_envs =
         if allowed_envs == [] do


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
