### PR TITLE
Demo using existing Hex functions to successfully find version info.

### DIFF
--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -29,7 +29,7 @@ defmodule Igniter.New.MixProject do
 
   def application do
     [
-      extra_applications: [:eex, :crypto, :public_key]
+      extra_applications: [:hex, :eex, :crypto, :public_key]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Igniter.MixProject do
   def application do
     [
       # if you change this, change it in the installer archive too.
-      extra_applications: [:logger, :public_key, :ssl, :inets, :eex],
+      extra_applications: [:hex, :logger, :public_key, :ssl, :inets, :eex],
       plt_add_apps: [:mix]
     ]
   end


### PR DESCRIPTION
`Igniter.Project.Deps.fetch_hex_api_url_and_headers(package, organization: org)` works as desired.

![image](https://github.com/user-attachments/assets/3a70884b-b348-4416-85cf-510455a0a545)

Please note the following corrections to misunderstandings I read from past discussions about this topic.

- The user should be a member of the org on hex.pm.
- The user **need only authenticate with** `mix hex.user auth`. 

I assume you will be able to replace most of the `req` stuff with code from the modules demonstrated in this PR. See: [Hex.API.Package.get](https://github.com/hexpm/hex/blob/v2.0.6/lib/hex/api/package.ex#L6) and friends. I did only take a cursory scan through the existing code though so your mileage may vary.

Note that `mix igniter.install org/package` fails before reaching the discussed function. 

Cheers.