### PR TITLE
Fix: undefined `found_issue` in `Igniter.Test.assert_has_issue/3` #297

### DIFF
--- a/lib/igniter/test.ex
+++ b/lib/igniter/test.ex
@@ -342,10 +342,10 @@ defmodule Igniter.Test do
   defmacro assert_has_issue(igniter, path \\ nil, issue) do
     quote bind_quoted: [igniter: igniter, path: path, issue: issue] do
       condition =
-        if is_binary(issue) do
-          issue == found_issue
+        if is_function(issue, 1) do
+          issue
         else
-          issue.(found_issue)
+          &(&1 == issue)
         end
 
       if path do


### PR DESCRIPTION
Close #297 

Modifies how `condition` is set in the beginning of the body of `Igniter.Test.assert_has_issue/3` to follow the same pattern as in `Igniter.Test.assert_has_warning/2` and `Igniter.Test.assert_has_notice/2`. The `found_issue` variable was being called before it was created.

All tests that were passing prior to this change still pass, but I didn't see any tests setup to test the macros in `Igniter.Test`.

# Contributor checklist
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
