### PR TITLE
fix: update writing generators section code example

### DIFF
--- a/documentation/writing-generators.md
+++ b/documentation/writing-generators.md
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.YourLib.Gen.YourThing do
       app_name,
       [:list_of_things],
       [module_name],
-      &Igniter.Code.List.prepend_new_to_list(&1, module_name)
+      updater: &Igniter.Code.List.prepend_new_to_list(&1, module_name)
     )
   end
 end


### PR DESCRIPTION
Hello! igniter is awesome!

Was following the example docs to write a generator and got an error while running the example code and thought I was doing something wrong. It turned out that the example seems to be outdated.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [X] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
