### PR TITLE
`igniter.new`: Don't run git init if already in git repo

### DIFF
--- a/installer/lib/mix/tasks/igniter.new.ex
+++ b/installer/lib/mix/tasks/igniter.new.ex
@@ -393,7 +393,7 @@ defmodule Mix.Tasks.Igniter.New do
     Igniter.Installer.Loading.with_spinner(
       "Initializing local git repository, staging all files, and committing",
       fn ->
-        case System.cmd("git", ["init"]) do
+        case maybe_init_git() do
           {_, 0} ->
             case System.cmd("git", ["add", "."]) do
               {_, 0} ->
@@ -414,6 +414,13 @@ defmodule Mix.Tasks.Igniter.New do
         end
       end
     )
+  end
+
+  defp maybe_init_git() do
+    case System.cmd("git", ["rev-parse", "--is-inside-work-tree"]) do
+      {_, 0} -> {true, 0}
+      {_, _} -> System.cmd("git", ["init"])
+    end
   end
 
   defp maybe_warn_outdated(latest_version, opts) do

--- a/installer/lib/mix/tasks/igniter.new.ex
+++ b/installer/lib/mix/tasks/igniter.new.ex
@@ -417,9 +417,15 @@ defmodule Mix.Tasks.Igniter.New do
   end
 
   defp maybe_init_git() do
-    case System.cmd("git", ["rev-parse", "--is-inside-work-tree"]) do
-      {_, 0} -> {true, 0}
-      {_, _} -> System.cmd("git", ["init"])
+    skip_git_check? = System.get_env("IGNITER_SKIP_GIT_CHECK") == "true"
+
+    if skip_git_check? do
+      System.cmd("git", ["init"])
+    else
+      case System.cmd("git", ["rev-parse", "--is-inside-work-tree"]) do
+        {_, 0} -> {true, 0}
+        {_, _} -> System.cmd("git", ["init"])
+      end
     end
   end
 

--- a/installer/test/mix/tasks/igniter.new_test.exs
+++ b/installer/test/mix/tasks/igniter.new_test.exs
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Igniter.NewTest do
               "mix",
               ["igniter.new", project_name, "--git", "--yes", "--no-installer-version-check"],
               stderr_to_stdout: true,
-              env: [{"MIX_ENV", "test"}]
+              env: [{"MIX_ENV", "test"}, {"IGNITER_SKIP_GIT_CHECK", "true"}]
             )
 
           if exit_code != 0 do
@@ -173,7 +173,7 @@ defmodule Mix.Tasks.Igniter.NewTest do
                 "--no-installer-version-check"
               ],
               stderr_to_stdout: true,
-              env: [{"MIX_ENV", "test"}]
+              env: [{"MIX_ENV", "test"}, {"IGNITER_SKIP_GIT_CHECK", "true"}]
             )
 
           assert exit_code == 0,

--- a/installer/test/mix/tasks/igniter.new_test.exs
+++ b/installer/test/mix/tasks/igniter.new_test.exs
@@ -113,6 +113,42 @@ defmodule Mix.Tasks.Igniter.NewTest do
     end
 
     @tag :integration
+    test "does not run git init when already in git project", %{tmp_dir: tmp_dir} do
+      if !git_available?() do
+        :ok
+      else
+        project_parent = "parent_folder"
+        project_name = "child_project_with_git_parent"
+
+        original_cwd = File.cwd!()
+
+        try do
+          File.cd!(tmp_dir)
+          File.mkdir!(project_parent)
+          File.cd!(project_parent)
+          System.cmd("git", ["init", "."])
+          assert File.exists?(".git"), "Git was not successfully set up in the parent folder"
+
+          # Run igniter.new with --git flag using System.cmd
+          {_output, exit_code} =
+            System.cmd(
+              "mix",
+              ["igniter.new", project_name, "--git", "--yes", "--no-installer-version-check"],
+              stderr_to_stdout: true,
+              env: [{"MIX_ENV", "test"}]
+            )
+
+          assert exit_code == 0
+
+          File.cd!(project_name)
+          refute File.exists?(".git"), "git should not be initialized when already in git project"
+        after
+          File.cd!(original_cwd)
+        end
+      end
+    end
+
+    @tag :integration
     test "git functionality works with other flags", %{tmp_dir: tmp_dir} do
       unless git_available?() do
         :ok


### PR DESCRIPTION
Skip running `git init` if the project is created inside a `git repo`. If the `IGNITER_SKIP_GIT_CHECK` environment variable is set to `"true"` the check is not performed, and `git init` will run unless the `--no-git` option is passed.

Resolves #327.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
