### PR TITLE
test: modify_config_code twice with keyword values

### DIFF
--- a/test/igniter/project/config_test.exs
+++ b/test/igniter/project/config_test.exs
@@ -699,6 +699,25 @@ defmodule Igniter.Project.ConfigTest do
 
       assert String.contains?(config, "config :fake, foo: [bar: true]")
     end
+
+    test "update existing config twice" do
+      zipper =
+        ~s"""
+        import Config
+        """
+        |> Sourceror.parse_string!()
+        |> Sourceror.Zipper.zip()
+
+      config =
+        zipper
+        |> Igniter.Project.Config.modify_config_code([:a], :app, 1)
+        |> elem(1)
+        |> Igniter.Project.Config.modify_config_code([:b], :app, 2)
+        |> elem(1)
+        |> Igniter.Util.Debug.code_at_node()
+
+      assert String.contains?(config, "config :app, a: 1, b: 2")
+    end
   end
 
   describe "configure_group" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

---

Hey @zachdaniel :wave: 

I spotted this issue while working on https://github.com/mimiquate/tower/pull/166.

And I was able to reproduce it here with this test case. But to be honest I am not sure I am calling the right functions and with the correct expectations.

I debugged a bit and the failure lead me to a few changes around Aug 2024...
- https://github.com/ash-project/igniter/pull/70
- https://github.com/ash-project/igniter/pull/71
- https://github.com/ash-project/igniter/pull/77
- https://github.com/ash-project/igniter/commit/853f27532cd2e321a72789eb9ee3b772d9f8dfe6

Thanks in advance!