### PR TITLE
feat(ci): add `mishka_chelekom` project to test ci

### DIFF
--- a/.github/workflows/test-projects.yml
+++ b/.github/workflows/test-projects.yml
@@ -41,7 +41,7 @@ jobs:
             {
               org: "mishka-group",
               name: "mishka_chelekom",
-              test-cmd: "mix test",
+              test-cmd: "mix test --only igniter",
             },
           ]
         otp: ["27.2"]


### PR DESCRIPTION
This adds the `mishka_chelekom` project to the GitHub Actions test matrix in `test-projects.yml` for CI test.
Because all Mishka Chelekom project tasks are Igniter, i did not add `--only igniter` like the other

Thank you in advance
