### PR TITLE
chore: Remove unused `require` statements as picked up by the Elixir 1.20.0-rc.1 compiler

### DIFF
--- a/lib/igniter/code/function.ex
+++ b/lib/igniter/code/function.ex
@@ -7,8 +7,6 @@ defmodule Igniter.Code.Function do
   Utilities for working with functions.
   """
 
-  require Igniter.Code.Common
-
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 

--- a/lib/igniter/code/keyword.ex
+++ b/lib/igniter/code/keyword.ex
@@ -6,7 +6,6 @@ defmodule Igniter.Code.Keyword do
   @moduledoc """
   Utilities for working with keyword.
   """
-  require Igniter.Code.Common
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 

--- a/lib/igniter/code/module.ex
+++ b/lib/igniter/code/module.ex
@@ -8,8 +8,6 @@ defmodule Igniter.Code.Module do
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 
-  require Logger
-
   @doc "The module name prefix based on the mix project's module name"
   @deprecated "Use `Igniter.Project.Module.module_name_prefix/1` instead"
   @spec module_name_prefix() :: module()

--- a/lib/igniter/project/application.ex
+++ b/lib/igniter/project/application.ex
@@ -5,7 +5,6 @@
 defmodule Igniter.Project.Application do
   @moduledoc "Codemods and tools for working with Application modules."
 
-  require Igniter.Code.Common
   require Igniter.Code.Function
 
   alias Igniter.Code.Common

--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -5,7 +5,6 @@
 defmodule Igniter.Project.Config do
   @moduledoc "Codemods and utilities for modifying Elixir config files."
 
-  require Igniter.Code.Function
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 

--- a/lib/igniter/project/deps.ex
+++ b/lib/igniter/project/deps.ex
@@ -4,7 +4,6 @@
 
 defmodule Igniter.Project.Deps do
   @moduledoc "Codemods and utilities for managing dependencies declared in mix.exs"
-  require Igniter.Code.Common
   alias Igniter.Code.Common
   alias Sourceror.Zipper
 

--- a/lib/igniter/project/module.ex
+++ b/lib/igniter/project/module.ex
@@ -5,7 +5,6 @@
 defmodule Igniter.Project.Module do
   @moduledoc "Codemods and utilities for interacting with modules"
 
-  require Igniter.Code.Common
   alias Igniter.Code.Common
   alias Sourceror.Zipper
   require Logger

--- a/lib/igniter/upgrades/igniter.ex
+++ b/lib/igniter/upgrades/igniter.ex
@@ -6,12 +6,10 @@ defmodule Igniter.Upgrades.Igniter do
   @moduledoc false
 
   alias Igniter.Code.Common
-  alias Igniter.Code.Function
   alias Igniter.Code.Module
   alias Sourceror.Zipper
 
   require Common
-  require Function
 
   @doc """
   Rewrites deprecated `igniter/2` callback to `igniter/1` if the module

--- a/lib/igniter/util/info.ex
+++ b/lib/igniter/util/info.ex
@@ -25,7 +25,6 @@ defmodule Igniter.Util.Info do
 
   @known_only_keys Keyword.keys(@known_only_options)
 
-  require Logger
   alias Igniter.Mix.Task.Info
 
   def compose_install_and_validate!(

--- a/lib/mix/task.ex
+++ b/lib/mix/task.ex
@@ -21,8 +21,6 @@ defmodule Igniter.Mix.Task do
   alias Igniter.Mix.Task.Args
   alias Igniter.Mix.Task.Info
 
-  require Logger
-
   @doc """
   Whether or not it supports being run in the root of an umbrella project
 


### PR DESCRIPTION
There's still one type warning in `assert_has_issue`:

```
     warning: unknown key .issues in expression:

         igniter.issues

     the given type does not have the given key:

         dynamic(%Rewrite{
           sources: term(),
           extensions: term(),
           hooks: term(),
           dot_formatter: term(),
           excluded: term()
         })

     where "igniter" was given the type:

         # type: dynamic(%Rewrite{})
         # from: lib/igniter/test.ex:427:24
         Rewrite.source(igniter, path)

     typing violation found at:
     │
 435 │       if !Enum.any?(igniter.issues, fn found_issue ->
     │                             ~~~~~~
     │
     └─ (igniter 0.7.0) lib/igniter/test.ex:435:29: Igniter.Test.assert_has_issue/3
```

But I thought I'd fix the low-hanging fruit. :)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
