### PR TITLE
fix: support all mix dep formats in recursively_compose_schema

### DIFF
--- a/lib/igniter/util/info.ex
+++ b/lib/igniter/util/info.ex
@@ -481,8 +481,8 @@ defmodule Igniter.Util.Info do
             alias_conflicts: alias_conflicts(schema, composing_schema, composing_task_name),
             composes: rest,
             extra_args?: schema.extra_args? || composing_schema.extra_args?,
-            installs: Keyword.merge(composing_schema.installs, schema.installs),
-            adds_deps: Keyword.merge(composing_schema.adds_deps, schema.adds_deps)
+            installs: merge_deps(composing_schema.installs, schema.installs),
+            adds_deps: merge_deps(composing_schema.adds_deps, schema.adds_deps)
         },
         argv,
         parent,
@@ -499,6 +499,11 @@ defmodule Igniter.Util.Info do
           Keyword.delete(opts, :only)
         )
     end
+  end
+
+  defp merge_deps(composed, parent) do
+    names = MapSet.new(parent, &elem(&1, 0))
+    Enum.reject(composed, fn entry -> elem(entry, 0) in names end) ++ parent
   end
 
   defp flag_conflicts(schema, composing_schema, composing_task_name) do

--- a/test/igniter/mix/task_test.exs
+++ b/test/igniter/mix/task_test.exs
@@ -293,6 +293,100 @@ defmodule Igniter.Mix.TaskTest do
     end
   end
 
+  describe "composed schema dep merging" do
+    # Covers every form in the `Igniter.Mix.Task.Info.dep` type:
+    #   {name, version}
+    #   {name, opts}
+    #   {name, version, opts}
+
+    defmodule Elixir.Mix.Tasks.ParentAddsDepsAllFormats do
+      use Igniter.Mix.Task
+
+      def info(_argv, _parent) do
+        %Igniter.Mix.Task.Info{
+          composes: ["child_adds_deps_all_formats"],
+          adds_deps: [
+            {:boundary, "~> 0.10", runtime: false},
+            {:parent_git_dep, git: "https://example.com/parent.git"},
+            {:parent_versioned, "~> 1.0"}
+          ]
+        }
+      end
+
+      def igniter(igniter), do: igniter
+    end
+
+    defmodule Elixir.Mix.Tasks.ChildAddsDepsAllFormats do
+      use Igniter.Mix.Task
+
+      def info(_argv, _parent) do
+        %Igniter.Mix.Task.Info{
+          adds_deps: [
+            {:cloak, "~> 1.1"},
+            {:child_git_dep, git: "https://example.com/child.git"},
+            {:child_with_opts, "~> 2.0", only: :test}
+          ]
+        }
+      end
+
+      def igniter(igniter), do: igniter
+    end
+
+    defmodule Elixir.Mix.Tasks.ParentInstallsAllFormats do
+      use Igniter.Mix.Task
+
+      def info(_argv, _parent) do
+        %Igniter.Mix.Task.Info{
+          composes: ["child_installs_all_formats"],
+          installs: [
+            {:boundary, "~> 0.10", runtime: false},
+            {:parent_git_install, git: "https://example.com/parent.git"},
+            {:parent_versioned_install, "~> 1.0"}
+          ]
+        }
+      end
+
+      def igniter(igniter), do: igniter
+    end
+
+    defmodule Elixir.Mix.Tasks.ChildInstallsAllFormats do
+      use Igniter.Mix.Task
+
+      def info(_argv, _parent) do
+        %Igniter.Mix.Task.Info{
+          installs: [
+            {:credo, "~> 1.7", only: [:dev, :test]},
+            {:child_git_install, git: "https://example.com/child.git"},
+            {:child_versioned_install, "~> 2.0"}
+          ]
+        }
+      end
+
+      def igniter(igniter), do: igniter
+    end
+
+    setup do
+      Elixir.Mix.Task.load_all()
+      :ok
+    end
+
+    test "adds_deps merges cleanly across every supported mix dep format" do
+      Igniter.Util.Info.validate!(
+        [],
+        Mix.Tasks.ParentAddsDepsAllFormats.info(nil, nil),
+        "parent_adds_deps_all_formats"
+      )
+    end
+
+    test "installs merges cleanly across every supported mix dep format" do
+      Igniter.Util.Info.validate!(
+        [],
+        Mix.Tasks.ParentInstallsAllFormats.info(nil, nil),
+        "parent_installs_all_formats"
+      )
+    end
+  end
+
   describe "parse_argv/1" do
     defmodule ExampleTaskWithOverriddenParseArgv do
       use Igniter.Mix.Task


### PR DESCRIPTION
## Summary

`Igniter.Util.Info.recursively_compose_schema/4` merges `installs` and `adds_deps` from composed tasks into the parent using `Keyword.merge/2`. That only works when every dep entry is shaped like `{name, value}` — any other supported mix dep form (e.g. `{:credo, "~> 1.7", only: [:dev, :test]}` or `{:my_dep, git: "..."}`) causes `Keyword.merge/2` to raise:

```
** (ArgumentError) expected a keyword list as the second argument,
   got: [{:boundary, "~> 0.10", [runtime: false]}]
```

The `dep` type at `lib/mix/task/info.ex:129-132` already documents all the accepted forms (`{name, version}`, `{name, opts}`, `{name, version, opts}`), and the rest of `Igniter.Util.Info` (`add_deps/3`, the installs normalization) handles them. The composition path just hadn't been updated to match.

### Repro

```elixir
defmodule Mix.Tasks.Parent do
  use Igniter.Mix.Task
  def info(_, _) do
    %Igniter.Mix.Task.Info{
      composes: ["child"],
      adds_deps: [{:boundary, "~> 0.10", runtime: false}]
    }
  end
  def igniter(i), do: i
end

defmodule Mix.Tasks.Child do
  use Igniter.Mix.Task
  def info(_, _), do: %Igniter.Mix.Task.Info{adds_deps: [{:cloak, "~> 1.1"}]}
  def igniter(i), do: i
end

# `mix igniter.install parent` raises the ArgumentError above.
```

### Fix

Replace the two `Keyword.merge/2` calls with a private `merge_deps/2` helper that dedupes by dep name (the first element of each entry) and leaves the original tuple shape untouched. The parent task's entry still wins on conflict, matching the previous `Keyword.merge/2` semantics.