### PR TITLE
fix: don't drop --key=value flags when value contains a dot

### DIFF
--- a/lib/igniter/util/info.ex
+++ b/lib/igniter/util/info.ex
@@ -389,7 +389,7 @@ defmodule Igniter.Util.Info do
           _ ->
             rest_args = args_for_group(["-" <> v2 | rest], group)
 
-            if String.contains?(arg, ".") do
+            if flag_namespaced?(arg) do
               rest_args
             else
               ["--#{arg}"] ++ rest_args
@@ -404,7 +404,7 @@ defmodule Igniter.Util.Info do
           _ ->
             rest_args = args_for_group(["-" <> v2 | rest], group)
 
-            if String.contains?(arg, ".") do
+            if flag_namespaced?(arg) do
               rest_args
             else
               ["-#{arg}"] ++ rest_args
@@ -419,7 +419,7 @@ defmodule Igniter.Util.Info do
           _ ->
             rest_args = args_for_group(rest, group)
 
-            if String.contains?(arg, ".") do
+            if flag_namespaced?(arg) do
               rest_args
             else
               ["--#{arg}"] ++ rest_args
@@ -434,7 +434,7 @@ defmodule Igniter.Util.Info do
           _ ->
             rest_args = args_for_group(rest, group)
 
-            if String.contains?(arg, ".") do
+            if flag_namespaced?(arg) do
               rest_args
             else
               ["-#{arg}"] ++ rest_args
@@ -447,6 +447,11 @@ defmodule Igniter.Util.Info do
       [] ->
         []
     end
+  end
+
+  defp flag_namespaced?(arg) do
+    [name | _] = String.split(arg, "=", parts: 2)
+    String.contains?(name, ".")
   end
 
   defp recursively_compose_schema(%Info{composes: []} = schema, _argv, _parent, _opts), do: schema

--- a/test/igniter/mix/task_test.exs
+++ b/test/igniter/mix/task_test.exs
@@ -467,4 +467,173 @@ defmodule Igniter.Mix.TaskTest do
       end
     end
   end
+
+  describe "args_for_group/2" do
+    alias Igniter.Util.Info
+
+    test "passes through flags that don't belong to another group" do
+      assert Info.args_for_group(["--option", "foo"], "my_group") == ["--option", "foo"]
+    end
+
+    test "passes through positional args" do
+      assert Info.args_for_group(["positional", "--option", "foo"], "my_group") ==
+               ["positional", "--option", "foo"]
+    end
+
+    test "strips this group's prefix from --my_group.option" do
+      assert Info.args_for_group(["--my_group.option", "foo"], "my_group") ==
+               ["--option", "foo"]
+    end
+
+    test "strips this group's prefix from --my_group.option=value" do
+      assert Info.args_for_group(["--my_group.option=foo"], "my_group") == ["--option=foo"]
+    end
+
+    test "strips this group's prefix from short alias -my_group.o" do
+      assert Info.args_for_group(["-my_group.o", "foo"], "my_group") == ["-o", "foo"]
+    end
+
+    test "drops other-group namespaced flags" do
+      assert Info.args_for_group(["--other_group.option", "foo"], "my_group") == ["foo"]
+    end
+
+    test "drops other-group namespaced flags with =value" do
+      assert Info.args_for_group(["--other_group.option=foo"], "my_group") == []
+    end
+
+    test "keeps --key=value when value contains a dot" do
+      assert Info.args_for_group(["--out=priv/schema.json"], "my_group") ==
+               ["--out=priv/schema.json"]
+    end
+
+    test "keeps --key=value when value is a module name with dots" do
+      assert Info.args_for_group(["--module=My.App.Mod"], "my_group") == ["--module=My.App.Mod"]
+    end
+
+    test "keeps -k=value when value contains a dot" do
+      assert Info.args_for_group(["-o=priv/schema.json"], "my_group") == ["-o=priv/schema.json"]
+    end
+
+    test "keeps two-arg form regardless of dots in value" do
+      assert Info.args_for_group(["--out", "priv/schema.json"], "my_group") ==
+               ["--out", "priv/schema.json"]
+    end
+
+    test "keeps a flag adjacent to another flag when neither is namespaced" do
+      assert Info.args_for_group(["--out=priv/foo.json", "--format=json"], "my_group") ==
+               ["--out=priv/foo.json", "--format=json"]
+    end
+
+    test "keeps the value of a stripped group prefix even when it contains dots" do
+      assert Info.args_for_group(["--my_group.out=priv/foo.json"], "my_group") ==
+               ["--out=priv/foo.json"]
+    end
+
+    test "returns empty for empty input" do
+      assert Info.args_for_group([], "my_group") == []
+    end
+  end
+
+  describe "schema type coverage with dotted values" do
+    defmodule Elixir.Mix.Tasks.AllTypesTask do
+      use Igniter.Mix.Task
+
+      def info(_argv, _parent) do
+        %Igniter.Mix.Task.Info{
+          schema: [
+            path: :string,
+            module: :string,
+            rate: :float,
+            port: :integer,
+            verbose: :boolean,
+            tag: :keep,
+            items: :csv
+          ],
+          aliases: [
+            p: :path,
+            r: :rate
+          ]
+        }
+      end
+
+      def igniter(igniter) do
+        send(self(), {:options, igniter.args.options})
+        igniter
+      end
+    end
+
+    test ":string with dot in value" do
+      Mix.Tasks.AllTypesTask.run(["--path=priv/schema.json"])
+      assert_received {:options, options}
+      assert options[:path] == "priv/schema.json"
+    end
+
+    test ":string module name with multiple dots" do
+      Mix.Tasks.AllTypesTask.run(["--module=My.App.Mod"])
+      assert_received {:options, options}
+      assert options[:module] == "My.App.Mod"
+    end
+
+    test ":string short alias with dotted value" do
+      Mix.Tasks.AllTypesTask.run(["-p=priv/foo.json"])
+      assert_received {:options, options}
+      assert options[:path] == "priv/foo.json"
+    end
+
+    test ":float survives parsing" do
+      Mix.Tasks.AllTypesTask.run(["--rate=1.5"])
+      assert_received {:options, options}
+      assert options[:rate] == 1.5
+    end
+
+    test ":float via short alias" do
+      Mix.Tasks.AllTypesTask.run(["-r=2.75"])
+      assert_received {:options, options}
+      assert options[:rate] == 2.75
+    end
+
+    test ":integer (no dot, sanity check)" do
+      Mix.Tasks.AllTypesTask.run(["--port=8080"])
+      assert_received {:options, options}
+      assert options[:port] == 8080
+    end
+
+    test ":boolean (no value, sanity check)" do
+      Mix.Tasks.AllTypesTask.run(["--verbose"])
+      assert_received {:options, options}
+      assert options[:verbose] == true
+    end
+
+    test ":keep accumulates values where some contain dots" do
+      Mix.Tasks.AllTypesTask.run(["--tag=plain", "--tag=value.with.dots", "--tag=other"])
+      assert_received {:options, options}
+      assert options[:tag] == ["plain", "value.with.dots", "other"]
+    end
+
+    test ":csv splits while preserving dots inside items" do
+      Mix.Tasks.AllTypesTask.run(["--items=a,b.x,c"])
+      assert_received {:options, options}
+      assert options[:items] == ["a", "b.x", "c"]
+    end
+
+    test "mixed types in a single invocation all survive" do
+      Mix.Tasks.AllTypesTask.run([
+        "--path=priv/schema.json",
+        "--rate=0.95",
+        "--port=4000",
+        "--verbose",
+        "--tag=v1.0",
+        "--tag=v1.1",
+        "--items=foo.json,bar.csv"
+      ])
+
+      assert_received {:options, options}
+      assert options[:path] == "priv/schema.json"
+      assert options[:rate] == 0.95
+      assert options[:port] == 4000
+      assert options[:verbose] == true
+      assert options[:tag] == ["v1.0", "v1.1"]
+      assert options[:items] == ["foo.json", "bar.csv"]
+    end
+  end
 end


### PR DESCRIPTION
> **I may be wrong, please do not consider this PR, but in my tests on my personal project, this problem was solved with this PR.**
 
`args_for_group/2` strips other-group namespaced flags (`--other_group.foo`) by checking `String.contains?(arg, ".")`, but `arg` is the whole `key=value` string — so any `--key=value` whose value has a dot gets silently dropped before reaching OptionParser.

  Affects every `:float`, paths, module names, IPs, etc.

      $ mix foo --rate=1.5            # before: []   after: [rate: 1.5]
      $ mix foo --out=priv/foo.json   # before: []   after: [out: "priv/foo.json"]
      $ mix foo --rate 1.5            # already worked (two-arg form)

  Fix: split on `=` first, only check the flag-name portion for `.`. Adds 14
  unit tests for `args_for_group/2` (none existed) and 10 end-to-end tests
  covering `:string`, `:float`, `:integer`, `:boolean`, `:keep`, `:csv` —
  prior coverage was `:string` only.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ x Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies
