### PR TITLE
Add --except to igniter.upgrade --all

### DIFF
--- a/lib/igniter/copied_tasks.ex
+++ b/lib/igniter/copied_tasks.ex
@@ -10,6 +10,7 @@ defmodule Igniter.CopiedTasks do
       yes: :boolean,
       yes_to_deps: :boolean,
       all: :boolean,
+      except: :keep,
       only: :string,
       target: :string,
       verbose: :boolean,

--- a/lib/igniter/upgrades.ex
+++ b/lib/igniter/upgrades.ex
@@ -32,14 +32,28 @@ defmodule Igniter.Upgrades do
         options
       end
 
-    packages =
-      packages
-      |> Enum.join(",")
-      |> String.split(",")
+    packages = split_package_names(packages)
+    except = except_packages(options)
 
     if Enum.empty?(packages) && !options[:all] do
       Mix.shell().error("""
       Must specify at least one package to upgrade or use --all to upgrade all packages.
+      """)
+
+      exit({:shutdown, 1})
+    end
+
+    if options[:all] && !Enum.empty?(packages) do
+      Mix.shell().error("""
+      Cannot specify both --all and package names.
+      """)
+
+      exit({:shutdown, 1})
+    end
+
+    if !Enum.empty?(except) && !options[:all] do
+      Mix.shell().error("""
+      Cannot specify --except without --all.
       """)
 
       exit({:shutdown, 1})
@@ -101,12 +115,9 @@ defmodule Igniter.Upgrades do
     original_mix_lock = Rewrite.Source.get(Rewrite.source!(igniter.rewrite, "mix.lock"), :content)
 
     validate_packages!(packages)
+    validate_except_packages!(except)
 
-    package_names =
-      packages
-      |> Enum.map(&(String.split(&1, "@") |> List.first()))
-      |> Enum.map(&String.to_atom/1)
-
+    deps_to_update = update_deps(packages, options)
     update_deps_args = update_deps_args(options)
 
     igniter =
@@ -119,7 +130,7 @@ defmodule Igniter.Upgrades do
           error_on_abort?: true,
           yes: options[:yes],
           yes_to_deps: options[:yes_to_deps],
-          update_deps: Enum.map(package_names, &to_string/1),
+          update_deps: deps_to_update,
           update_deps_args: update_deps_args,
           force?: true
         )
@@ -267,6 +278,104 @@ defmodule Igniter.Upgrades do
     end
   end
 
+  @doc false
+  def update_deps(packages, options) do
+    except = except_packages(options)
+
+    cond do
+      options[:all] && !Enum.empty?(except) ->
+        # Mix has no --except, so expand --all into the deps this env/target can update.
+        updatable_dep_names(options)
+        |> Enum.reject(&(&1 in except))
+
+      options[:all] ->
+        [:all]
+
+      true ->
+        packages
+        |> Enum.map(&(String.split(&1, "@") |> List.first()))
+        |> Enum.map(&to_string/1)
+    end
+  end
+
+  @doc false
+  def except_packages(options) do
+    options
+    |> option_values(:except)
+    |> split_package_names()
+    |> Enum.map(&(String.split(&1, "@") |> List.first()))
+  end
+
+  defp split_package_names(packages) do
+    packages
+    |> List.wrap()
+    |> List.flatten()
+    |> Enum.join(",")
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp option_values(options, key) do
+    if Keyword.keyword?(options) do
+      Keyword.get_values(options, key)
+    else
+      List.wrap(options[key])
+    end
+  end
+
+  defp updatable_dep_names(options) do
+    Mix.Project.get!().project()[:deps]
+    |> Enum.filter(&dep_in_requested_env?(&1, options))
+    |> Enum.filter(&dep_for_requested_target?(&1, options))
+    |> Enum.map(&(dep_name(&1) |> to_string()))
+  end
+
+  defp dep_in_requested_env?(dep, options) do
+    allowed_envs =
+      dep
+      |> dep_opts()
+      |> Keyword.get(:only)
+      |> List.wrap()
+
+    allowed_envs == [] || requested_env(options) in Enum.map(allowed_envs, &to_string/1)
+  end
+
+  defp requested_env(options) do
+    (options[:only] || Mix.env())
+    |> to_string()
+  end
+
+  defp dep_for_requested_target?(dep, options) do
+    allowed_targets =
+      dep
+      |> dep_opts()
+      |> Keyword.get(:targets)
+      |> List.wrap()
+
+    allowed_targets == [] || requested_target(options) in Enum.map(allowed_targets, &to_string/1)
+  end
+
+  defp requested_target(options) do
+    (options[:target] || mix_target())
+    |> to_string()
+  end
+
+  defp mix_target do
+    if function_exported?(Mix, :target, 0) do
+      Mix.target()
+    else
+      :host
+    end
+  end
+
+  # Dependency declarations have multiple tuple shapes.
+  defp dep_name(dep), do: elem(dep, 0)
+
+  defp dep_opts({_dep, opts}) when is_list(opts), do: opts
+  defp dep_opts({_dep, _requirement, opts}) when is_list(opts), do: opts
+  defp dep_opts(_dep), do: []
+
   defp update_deps_args(options) do
     update_deps_args =
       if only = options[:only] do
@@ -289,11 +398,7 @@ defmodule Igniter.Upgrades do
         update_deps_args
       end
 
-    if options[:all] do
-      ["--all"] ++ update_deps_args
-    else
-      update_deps_args
-    end
+    update_deps_args
   end
 
   defp apply_updates(igniter, {package, from, to}) do
@@ -455,5 +560,23 @@ defmodule Igniter.Upgrades do
         """)
       end
     end)
+  end
+
+  defp validate_except_packages!(packages) do
+    dependency_names =
+      Mix.Project.get!().project()[:deps]
+      |> Enum.map(&(dep_name(&1) |> to_string()))
+
+    unknown_packages =
+      packages
+      |> Enum.reject(&(&1 in dependency_names))
+
+    if unknown_packages != [] do
+      Mix.shell().error("""
+      Cannot exclude unknown dependencies from upgrade: #{Enum.join(unknown_packages, ", ")}.
+      """)
+
+      exit({:shutdown, 1})
+    end
   end
 end

--- a/lib/igniter/upgrades.ex
+++ b/lib/igniter/upgrades.ex
@@ -326,8 +326,9 @@ defmodule Igniter.Upgrades do
 
   defp updatable_dep_names(options) do
     Mix.Project.get!().project()[:deps]
-    |> Enum.filter(&dep_in_requested_env?(&1, options))
-    |> Enum.filter(&dep_for_requested_target?(&1, options))
+    |> Enum.filter(
+      &(dep_in_requested_env?(&1, options) and dep_for_requested_target?(&1, options))
+    )
     |> Enum.map(&(dep_name(&1) |> to_string()))
   end
 

--- a/lib/mix/tasks/igniter.upgrade.ex
+++ b/lib/mix/tasks/igniter.upgrade.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Igniter.Upgrade do
 
   * `--yes` - Accept all changes automatically
   * `--all` - Upgrades all dependencies
+  * `--except` - when used with `--all`, skips the given comma-separated dependencies. Can be provided multiple times.
   * `--only` - only fetches dependencies for given environment
   * `--verbose` - display additional output from various operations
   * `--target` - only fetches dependencies for given target

--- a/test/igniter/upgrades_test.exs
+++ b/test/igniter/upgrades_test.exs
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2024 igniter contributors <https://github.com/ash-project/igniter/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Igniter.UpgradesTest do
+  use ExUnit.Case, async: true
+
+  test "igniter.upgrade parses repeated --except options" do
+    options =
+      Igniter.Mix.Task.__options__!(
+        Mix.Tasks.Igniter.Upgrade,
+        ["--all", "--except", "rewrite, glob_ex", "--except", "jason"]
+      )
+
+    assert Igniter.Upgrades.except_packages(options) == ["rewrite", "glob_ex", "jason"]
+  end
+
+  describe "update_deps/2" do
+    test "updates all dependencies without exclusions" do
+      assert Igniter.Upgrades.update_deps([], all: true) == [:all]
+    end
+
+    test "expands --all --except into the project dependencies minus exclusions" do
+      deps = Igniter.Upgrades.update_deps([], all: true, except: ["rewrite,glob_ex"])
+
+      assert "jason" in deps
+      refute "rewrite" in deps
+      refute "glob_ex" in deps
+    end
+
+    test "normalizes repeated except values" do
+      deps = Igniter.Upgrades.update_deps([], all: true, except: ["rewrite", "glob_ex"])
+
+      assert "jason" in deps
+      refute "rewrite" in deps
+      refute "glob_ex" in deps
+    end
+
+    test "expands --all --except from dependencies in the requested environment" do
+      deps = Igniter.Upgrades.update_deps([], all: true, only: "prod", except: ["rewrite"])
+
+      assert "jason" in deps
+      refute "rewrite" in deps
+      refute "credo" in deps
+    end
+
+    test "normalizes except values with versions" do
+      deps = Igniter.Upgrades.update_deps([], all: true, except: ["jason@1.4"])
+
+      refute "jason" in deps
+    end
+
+    test "updates explicit dependencies by package name" do
+      assert Igniter.Upgrades.update_deps(["jason@1.4", "req"], []) == ["jason", "req"]
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
Resolves issue https://github.com/ash-project/igniter/issues/353
Adds support for excluding dependencies when upgrading all deps:

```
mix igniter.upgrade --all --except rewrite
```
This supports comma-separated values and repeated flags:
```
mix igniter.upgrade --all --except rewrite --except jason
mix igniter.upgrade --all --except rewrite,jason
mix igniter.upgrade --all --except "rewrite, jason"
```
## Changes
- Adds --except to igniter.upgrade options.
- Expands --all --except into an explicit env/target-aware dependency list.
- Validates invalid option combinations and unknown excluded deps.
- Normalizes dep@version values to dep.
- Adds tests for parsing, exclusions, env filtering, and explicit package upgrades.
