### PR TITLE
Add scoped configure/6 options for runtime env blocks

### DIFF
--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -259,6 +259,10 @@ defmodule Igniter.Project.Config do
   * `failure_message` - A message to display to the user if the configuration change is unsuccessful.
   * `updater` - `t:updater/0`. A function that takes a zipper at a currently configured value and returns a new zipper with the value updated.
   * `after` - `t:after_predicate/0`. Moves to the last node that matches the predicate. Useful to guarantee a `config` is placed after a specific node.
+  * `env` - An atom like `:prod`. Scopes the configuration change to the matching `config_env()` block in the file.
+  * `in_scope` - Cursor patterns that scope where the configuration change is applied.
+    See `Igniter.Code.Common.move_to_cursor_match_in_scope/2`.
+  * `on_scope_missing` - `t:on_scope_missing/0`. What to do when the scope cannot be found. Defaults to `:error`.
   """
   @spec configure(
           Igniter.t(),
@@ -269,6 +273,8 @@ defmodule Igniter.Project.Config do
           opts :: Keyword.t()
         ) :: Igniter.t()
   def configure(igniter, file_name, app_name, config_path, value, opts \\ []) do
+    validate_scope_opts!(opts) # Helper function which makes it so that the user can't pass both :env and :in_scope options to configure/6.
+
     file_contents = "import Config\n"
 
     file_path = config_file_path(igniter, file_name)
@@ -290,11 +296,23 @@ defmodule Igniter.Project.Config do
         nil ->
           {:warning, bad_config_message(app_name, file_path, config_path, value, opts)}
 
-        _ ->
-          modify_config_code(zipper, config_path, app_name, value,
-            updater: updater,
-            after: opts[:after]
-          )
+        _ -> # Takes in the user's key/value pairs that they plug in, determines what scope we're targeting - an environment? or a custom pattern?
+          case move_into_scope(zipper, opts, app_name, file_path, config_path) do
+            :skip ->
+              {:ok, zipper}
+
+            {:ok, scoped_zipper} -> # Searches for patterns inside of the project's runtime.exs file, it then inserts and updates the config accordingly.
+              modify_config_code(scoped_zipper, config_path, app_name, value,
+                updater: updater,
+                after: opts[:after]
+              )
+
+            {:warning, warning} ->
+              {:warning, warning}
+
+            {:error, error} ->
+              {:error, error}
+          end
       end
     end)
   end
@@ -840,5 +858,92 @@ defmodule Igniter.Project.Config do
       _ ->
         false
     end)
+  end
+
+  # Helper function which makes it so that the user can't pass both :env and :in_scope options to configure/6.
+  defp validate_scope_opts!(opts) do
+    if opts[:in_scope] && opts[:env] do
+      raise ArgumentError, "cannot pass both :env and :in_scope options to configure/6"
+    end
+  end
+
+  # Determines what scope we're targeting - an environment? or a custom pattern?
+  defp scope_patterns(opts) do
+    cond do
+      patterns = opts[:in_scope] ->
+        patterns
+
+      env = opts[:env] ->
+        env_scope_patterns(env)
+
+      true ->
+        nil
+    end
+  end
+
+  # Defines what the env pattern looks like.
+  defp env_scope_patterns(env) do
+    [
+      """
+      if config_env() == #{inspect(env)} do
+        __cursor__()
+      end
+      """,
+      """
+      if #{inspect(env)} == config_env() do
+        __cursor__()
+      end
+      """
+    ]
+  end
+
+  # Function to control zipper/cursor around the file into the correct scope before we start editing. If no scope, return the zipper as is. If scope, move the cursor to the correct position. If scope not found, handle the error.
+  defp move_into_scope(zipper, opts, app_name, file_path, config_path) do
+    case scope_patterns(opts) do
+      nil ->
+        {:ok, zipper}
+
+      patterns ->
+        case Common.move_to_cursor_match_in_scope(zipper, patterns) do
+          {:ok, scoped_zipper} ->
+            {:ok, scoped_zipper}
+
+          :error ->
+            handle_scope_missing(zipper, opts, app_name, file_path, config_path)
+        end
+    end
+  end
+
+  # When the scope is not found, determine whether the user wants to skip the config change, or handle the error. The user can even define a customer fallback function to handle the error.
+  defp handle_scope_missing(zipper, opts, app_name, file_path, config_path) do
+    case Keyword.get(opts, :on_scope_missing, :error) do
+      :error ->
+        {:warning, scope_missing_message(app_name, file_path, config_path, opts)}
+
+      :skip ->
+        :skip
+
+      fallback when is_function(fallback, 1) ->
+        case fallback.(zipper) do
+          {:ok, scoped_zipper} -> {:ok, scoped_zipper}
+          :error -> {:warning, scope_missing_message(app_name, file_path, config_path, opts)}
+          {:warning, message} -> {:warning, message}
+          {:error, message} -> {:error, message}
+        end
+    end
+  end
+
+  # What will display to the user when the scope is not found.
+  defp scope_missing_message(app_name, file_path, config_path, opts) do
+    scope_description =
+      cond do
+        env = opts[:env] -> "if config_env() == #{inspect(env)}"
+        opts[:in_scope] -> "the provided scope pattern(s)"
+        true -> "the requested scope"
+      end
+
+    """
+    Could not find #{scope_description} in `#{file_path}` to set #{inspect([app_name | config_path])}.
+    """
   end
 end

--- a/lib/igniter/project/config.ex
+++ b/lib/igniter/project/config.ex
@@ -11,6 +11,15 @@ defmodule Igniter.Project.Config do
   @type updater :: (Sourceror.Zipper.t() -> {:ok, Sourceror.Zipper.t()}) | :error | nil
   @type after_predicate :: (Sourceror.Zipper.t() -> boolean())
 
+  @type on_scope_missing ::
+          :error
+          | :skip
+          | (Sourceror.Zipper.t() ->
+               {:ok, Sourceror.Zipper.t()}
+               | :error
+               | {:warning, String.t()}
+               | {:error, String.t()})
+
   @type config_group_item ::
           {list(term) | term(), term()} | {list(term) | term(), term(), Keyword.t()}
 
@@ -23,6 +32,11 @@ defmodule Igniter.Project.Config do
 
   * `failure_message` - A message to display to the user if the configuration change is unsuccessful.
   * `after` - `t:after_predicate/0`. Moves to the last node that matches the predicate.
+  * `env` - An atom like `:prod`. Scopes the configuration change to the matching `config_env()` block.
+  * `in_scope` - Cursor patterns that scope where the configuration change is applied.
+    See `Igniter.Code.Common.move_to_cursor_match_in_scope/2`.
+  * `on_scope_missing` - `t:on_scope_missing/0`. What to do when the scope cannot be found.
+    Defaults to `:error`.
   """
   @spec configure_new(Igniter.t(), Path.t(), atom(), list(atom), term(), opts :: Keyword.t()) ::
           Igniter.t()
@@ -273,7 +287,7 @@ defmodule Igniter.Project.Config do
           opts :: Keyword.t()
         ) :: Igniter.t()
   def configure(igniter, file_name, app_name, config_path, value, opts \\ []) do
-    validate_scope_opts!(opts) # Helper function which makes it so that the user can't pass both :env and :in_scope options to configure/6.
+    validate_scope_opts!(opts)
 
     file_contents = "import Config\n"
 
@@ -296,12 +310,12 @@ defmodule Igniter.Project.Config do
         nil ->
           {:warning, bad_config_message(app_name, file_path, config_path, value, opts)}
 
-        _ -> # Takes in the user's key/value pairs that they plug in, determines what scope we're targeting - an environment? or a custom pattern?
+        _ ->
           case move_into_scope(zipper, opts, app_name, file_path, config_path) do
             :skip ->
               {:ok, zipper}
 
-            {:ok, scoped_zipper} -> # Searches for patterns inside of the project's runtime.exs file, it then inserts and updates the config accordingly.
+            {:ok, scoped_zipper} ->
               modify_config_code(scoped_zipper, config_path, app_name, value,
                 updater: updater,
                 after: opts[:after]
@@ -860,14 +874,12 @@ defmodule Igniter.Project.Config do
     end)
   end
 
-  # Helper function which makes it so that the user can't pass both :env and :in_scope options to configure/6.
   defp validate_scope_opts!(opts) do
     if opts[:in_scope] && opts[:env] do
       raise ArgumentError, "cannot pass both :env and :in_scope options to configure/6"
     end
   end
 
-  # Determines what scope we're targeting - an environment? or a custom pattern?
   defp scope_patterns(opts) do
     cond do
       patterns = opts[:in_scope] ->
@@ -881,7 +893,6 @@ defmodule Igniter.Project.Config do
     end
   end
 
-  # Defines what the env pattern looks like.
   defp env_scope_patterns(env) do
     [
       """
@@ -897,7 +908,6 @@ defmodule Igniter.Project.Config do
     ]
   end
 
-  # Function to control zipper/cursor around the file into the correct scope before we start editing. If no scope, return the zipper as is. If scope, move the cursor to the correct position. If scope not found, handle the error.
   defp move_into_scope(zipper, opts, app_name, file_path, config_path) do
     case scope_patterns(opts) do
       nil ->
@@ -914,7 +924,6 @@ defmodule Igniter.Project.Config do
     end
   end
 
-  # When the scope is not found, determine whether the user wants to skip the config change, or handle the error. The user can even define a customer fallback function to handle the error.
   defp handle_scope_missing(zipper, opts, app_name, file_path, config_path) do
     case Keyword.get(opts, :on_scope_missing, :error) do
       :error ->
@@ -933,7 +942,6 @@ defmodule Igniter.Project.Config do
     end
   end
 
-  # What will display to the user when the scope is not found.
   defp scope_missing_message(app_name, file_path, config_path, opts) do
     scope_description =
       cond do

--- a/test/igniter/project/config_test.exs
+++ b/test/igniter/project/config_test.exs
@@ -601,6 +601,192 @@ defmodule Igniter.Project.ConfigTest do
     end
   end
 
+  describe "configure/6 scoped options" do
+    test "inserts config inside prod block with env: :prod" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+
+      if config_env() == :prod do
+      end
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "postgres://localhost",
+        env: :prod
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      4 + |  config :fake, database_url: "postgres://localhost"
+      """)
+    end
+
+    test "inserts config inside reversed prod block with env: :prod" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+
+      if :prod == config_env() do
+      end
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "postgres://localhost",
+        env: :prod
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      4 + |  config :fake, database_url: "postgres://localhost"
+      """)
+    end
+
+    test "updates existing key inside prod block without duplicating at top level" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+
+      config :fake, other: true
+
+      if config_env() == :prod do
+        config :fake, database_url: "old"
+      end
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "new",
+        env: :prod
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      6 - |  config :fake, database_url: "old"
+      6 + |  config :fake, database_url: "new"
+      """)
+    end
+
+    test "inserts config inside custom scope with in_scope:" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+
+      if some_condition do
+      end
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:key],
+        "value",
+        in_scope: [
+          """
+          if some_condition do
+            __cursor__()
+          end
+          """
+        ]
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      4 + |  config :fake, key: "value"
+      """)
+    end
+
+    test "raises when both env and in_scope are provided" do
+      assert_raise ArgumentError, ~r/cannot pass both :env and :in_scope/, fn ->
+        test_project()
+        |> apply_igniter!()
+        |> Igniter.Project.Config.configure(
+          "runtime.exs",
+          :fake,
+          [:key],
+          "value",
+          env: :prod,
+          in_scope: ["if config_env() == :prod do\n__cursor__()\nend"]
+        )
+      end
+    end
+
+    test "warns when scope is missing by default" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "postgres://localhost",
+        env: :prod
+      )
+      |> assert_unchanged()
+      |> assert_has_warning(fn warning ->
+        String.contains?(warning, "Could not find if config_env() == :prod")
+      end)
+    end
+
+    test "skips when scope is missing and on_scope_missing: :skip" do
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "postgres://localhost",
+        env: :prod,
+        on_scope_missing: :skip
+      )
+      |> assert_unchanged()
+    end
+
+    test "uses fallback when scope is missing" do
+      patterns = [
+        """
+        if config_env() == :prod do
+          __cursor__()
+        end
+        """
+      ]
+
+      test_project()
+      |> Igniter.create_new_file("config/runtime.exs", """
+      import Config
+      """)
+      |> apply_igniter!()
+      |> Igniter.Project.Config.configure(
+        "runtime.exs",
+        :fake,
+        [:database_url],
+        "postgres://localhost",
+        env: :prod,
+        on_scope_missing: fn zipper ->
+          case zipper
+               |> Igniter.Code.Common.add_code("""
+               if config_env() == :prod do
+               end
+               """)
+               |> Igniter.Code.Common.move_to_cursor_match_in_scope(patterns) do
+            {:ok, scoped_zipper} -> {:ok, scoped_zipper}
+            :error -> :error
+          end
+        end
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      3 + |if config_env() == :prod do
+      4 + |  config :fake, database_url: "postgres://localhost"
+      5 + |end
+      """)
+    end
+  end
+
   describe "configures_key?/3" do
     setup do
       %{


### PR DESCRIPTION
## Summary

Closes #316.

Adds optional scoping to `Igniter.Project.Config.configure/6` and `configure_new/5`, allowing install tasks to add or update configuration inside a specific code block instead of operating only at the file's top level.

For example, callers can now place configuration inside:

```elixir
if config_env() == :prod do
  # Configuration is inserted here
end
```

## New options

| Option | Purpose |
|---|---|
| `env: :prod` | Targets a runtime environment block. Supports both `config_env() == :prod` and `:prod == config_env()`. |
| `in_scope: [pattern, ...]` | Targets custom scopes using cursor patterns. |
| `on_scope_missing:` | Controls missing-scope behavior with `:error`, `:skip`, or a fallback function. |

`env:` and `in_scope:` are mutually exclusive.

## Implementation

When a scope is requested, `configure/6`:

1. Resolves the scope from `env:` or `in_scope:`.
2. Moves the zipper into the matching block using `Igniter.Code.Common.move_to_cursor_match_in_scope/2`.
3. Runs the existing `modify_config_code/5` logic from within that scope.

Existing `:after` and `:updater` behavior is preserved and applied inside the selected scope.

When no scope option is supplied, the existing behavior of `configure/6` is unchanged.

## Example

```elixir
Igniter.Project.Config.configure(
  igniter,
  "runtime.exs",
  :my_app,
  [:database_url],
  {:system, "DATABASE_URL"},
  env: :prod
)
```

### Before

```elixir
import Config

if config_env() == :prod do
end
```

### After

```elixir
import Config

if config_env() == :prod do
  config :my_app, database_url: {:system, "DATABASE_URL"}
end
```

This provides a shared API for behavior currently implemented separately by installers such as `ash_postgres` and Tower.

## Missing scopes

The default behavior returns a warning and leaves the file unchanged.

Callers may instead skip the operation:

```elixir
on_scope_missing: :skip
```

Or provide a fallback function that creates or locates an appropriate scope:

```elixir
on_scope_missing: fn zipper ->
  # Return {:ok, scoped_zipper} to continue configuration.
end
```

## Test coverage

- [x] Inserts configuration into an existing production block with `env: :prod`
- [x] Supports the reversed `:prod == config_env()` condition
- [x] Updates an existing key inside the selected block without adding a top-level duplicate
- [x] Supports custom scopes through `in_scope:`
- [x] Raises an `ArgumentError` when both `env:` and `in_scope:` are provided
- [x] Warns and leaves the file unchanged when the scope is missing by default
- [x] Skips the operation with `on_scope_missing: :skip`
- [x] Runs a custom fallback function when the scope is missing
- [x] Preserves existing behavior when no scope option is supplied

## Validation

- [x] `mix test test/igniter/project/config_test.exs`
- [x] `mix test`
- [x] `mix check`

## Possible follow-ups

These are intentionally outside the scope of this PR:

- Refactor `configure_runtime_env/6` to delegate to `configure(..., env: env)`
- Update Tower and `ash_postgres` installers to use the new API

## Contributor checklist

Leave items that do not apply unchecked.

- [x] I accept the AI Policy, or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
