### PR TITLE
fix: resolve Elixir 1.20 type-check warnings

### DIFF
--- a/lib/igniter/test.ex
+++ b/lib/igniter/test.ex
@@ -424,7 +424,7 @@ defmodule Igniter.Test do
       end
 
     if path do
-      source = Rewrite.source(igniter, path)
+      source = Rewrite.source(igniter.rewrite, path)
 
       issues =
         case source do

--- a/lib/igniter/util/info.ex
+++ b/lib/igniter/util/info.ex
@@ -311,7 +311,7 @@ defmodule Igniter.Util.Info do
 
         Please install it manually, for example:
 
-            `MIX_ENV=#{Enum.at(only, 0)} mix igniter.install #{dependency}`.
+            `MIX_ENV=#{Enum.at(only, 0)} mix igniter.install #{name}`.
         """)
       else
         _ ->


### PR DESCRIPTION
- `Igniter.Test.assert_has_issue/3` passed `%Igniter{}` to `Rewrite.source/2`, which expects `%Rewrite{}`; use `igniter.rewrite`. This also fixes a latent bug and resolves the cascading unknown-key warning on `igniter.issues`.
- `Igniter.Util.Info.add_deps/3` interpolated the dep tuple directly; use the bound dep name atom so the suggested install command is valid.