### PR TITLE
improvement: add `Igniter.Libs.Phoenix.web_module_for_router/2`

### DIFF
--- a/lib/igniter/libs/phoenix.ex
+++ b/lib/igniter/libs/phoenix.ex
@@ -92,6 +92,41 @@ defmodule Igniter.Libs.Phoenix do
     Module.concat(web_module(igniter), suffix)
   end
 
+  @doc """
+  Returns the web module that the given `router` belongs to.
+
+  Reads the router's `use <WebModule>, :router` declaration, which is the module
+  that generated modules (`use <WebModule>, :controller`, `:verified_routes`,
+  etc.) should reference. This lets installers place generated modules alongside
+  the selected router rather than assuming the application's default web module.
+
+  Falls back to `web_module/1` when the router uses `Phoenix.Router` directly or
+  cannot be found.
+  """
+  @spec web_module_for_router(Igniter.t(), module()) :: {Igniter.t(), module()}
+  def web_module_for_router(igniter, router) do
+    case Igniter.Project.Module.find_module(igniter, router) do
+      {:ok, {igniter, _source, zipper}} ->
+        {igniter, web_module_from_router_use(zipper) || web_module(igniter)}
+
+      {:error, igniter} ->
+        {igniter, web_module(igniter)}
+    end
+  end
+
+  defp web_module_from_router_use(zipper) do
+    with {:ok, use_call} <-
+           Igniter.Code.Function.move_to_function_call(zipper, :use, 2, fn call ->
+             Igniter.Code.Function.argument_equals?(call, 1, :router)
+           end),
+         {:ok, arg} <- Igniter.Code.Function.move_to_nth_argument(use_call, 0),
+         {:__aliases__, _, parts} <- Igniter.Code.Common.expand_aliases(arg).node do
+      Module.concat(parts)
+    else
+      _ -> nil
+    end
+  end
+
   @doc "Gets the list of endpoints that use a given router"
   @spec endpoints_for_router(igniter :: Igniter.t(), router :: module()) ::
           {Igniter.t(), list(module())}

--- a/test/igniter/libs/phoenix_test.exs
+++ b/test/igniter/libs/phoenix_test.exs
@@ -71,6 +71,41 @@ defmodule Igniter.Libs.PhoenixTest do
     assert Igniter.Libs.Phoenix.web_module_name(test_project(), "Suffix") == TestWeb.Suffix
   end
 
+  describe "web_module_for_router/2" do
+    test "reads the web module from the router's `use _, :router` declaration" do
+      igniter =
+        test_project()
+        |> Igniter.create_new_file("lib/admin_web/router.ex", """
+        defmodule AdminWeb.Router do
+          use AdminWeb, :router
+        end
+        """)
+        |> apply_igniter!()
+
+      assert {_igniter, AdminWeb} =
+               Igniter.Libs.Phoenix.web_module_for_router(igniter, AdminWeb.Router)
+    end
+
+    test "falls back to `web_module/1` for a `use Phoenix.Router` router" do
+      igniter =
+        test_project()
+        |> Igniter.create_new_file("lib/plain/router.ex", """
+        defmodule Plain.Router do
+          use Phoenix.Router
+        end
+        """)
+        |> apply_igniter!()
+
+      assert {_igniter, TestWeb} =
+               Igniter.Libs.Phoenix.web_module_for_router(igniter, Plain.Router)
+    end
+
+    test "falls back to `web_module/1` when the router cannot be found" do
+      assert {_igniter, TestWeb} =
+               Igniter.Libs.Phoenix.web_module_for_router(test_project(), Missing.Router)
+    end
+  end
+
   describe "list_web_modules/1" do
     test "finds web modules that are one level deep and end with Web" do
       igniter =


### PR DESCRIPTION
## Motivation

Installers that generate modules relative to a *selected* router have no way to derive the correct web module for that router. `web_module/1` derives the web module from the application's root module prefix (`<AppPrefix>Web`) and ignores any router selection entirely.

This bites any project with more than one web namespace (umbrella apps, multi-`*Web` setups): the user picks, say, `AdminWeb.Router` via `select_router/2`, but generated controllers/overrides/etc. still land under `AppWeb`.

Concrete case: https://github.com/team-alembic/ash_authentication_phoenix/issues/654 — the AshAuthenticationPhoenix installer creates its `AuthController`, `AuthOverrides`, `LiveUserAuth`, etc. under the assumed `AppWeb` rather than the selected router's namespace.

## What this does

Adds `Igniter.Libs.Phoenix.web_module_for_router/2`, which reads the router's `use <WebModule>, :router` declaration and returns that module. That's precisely the module generated code should reference in `use <WebModule>, :controller` / `:verified_routes`, so callers can place generated modules alongside the selected router.

It sits beside the existing `web_module/1`, `web_module_name/2`, and `endpoints_for_router/2` helpers and follows the `{igniter, result}` return convention of `endpoints_for_router/2`.

## Fallback behaviour

Falls back to `web_module/1` when:
- the router uses `Phoenix.Router` directly (no web module to read), or
- the router module can't be found.

## Tests

Adds a `web_module_for_router/2` describe block covering the `use _, :router` read plus both fallback paths.